### PR TITLE
Add json query support for index

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,7 +1,9 @@
 // eslint-disable-next-line import/no-cycle
 import { sampleRUM, isInternalPage } from './lib-franklin.js';
 // eslint-disable-next-line import/no-cycle
-import { getEnvType, loadConsentManager, loadScript } from './scripts.js';
+import {
+  getEnvType, loadConsentManager, loadScript, fetchIndex, queryIndex,
+} from './scripts.js';
 
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
@@ -25,4 +27,8 @@ window.addEventListener('consentmanager', () => {
 if (!isInternalPage()) {
   await loadConsentManager();
   await loadAdobeLaunch();
+  // TODO Remove. Just for testing.
+  const json = await fetchIndex('query-index');
+  const results = queryIndex(json, ['title', 'description'], ['category', '=', 'Newsroom'], ['newsdate', 'desc'], 3);
+  console.log(JSON.stringify(results, null, 2));
 }

--- a/scripts/json-query.js
+++ b/scripts/json-query.js
@@ -1,0 +1,55 @@
+/* eslint-disable max-len */
+export default function query(select, from, where, orderBy, rowCount) {
+  // Validate input parameters
+  if (!Array.isArray(select) || !Array.isArray(from) || !Array.isArray(where) || where.length !== 3) {
+    throw new Error('Invalid input parameters');
+  }
+
+  // Extract the filter condition components
+  const [field, operator, value] = where;
+
+  // Sort the 'from' array based on the orderBy parameter
+  if (orderBy) {
+    const [orderByField, sortOrder] = orderBy;
+    from.sort((a, b) => {
+      const aValue = a[orderByField];
+      const bValue = b[orderByField];
+      if (sortOrder === 'asc') {
+        // eslint-disable-next-line no-nested-ternary
+        return aValue < bValue ? -1 : aValue > bValue ? 1 : 0;
+      } if (sortOrder === 'desc') {
+        // eslint-disable-next-line no-nested-ternary
+        return bValue < aValue ? -1 : bValue > aValue ? 1 : 0;
+      }
+      throw new Error('Invalid sortOrder');
+    });
+  }
+
+  // Filter the 'from' array based on the condition
+  const filteredData = from.filter((item) => {
+    switch (operator) {
+      case '<':
+        return item[field] < parseFloat(value);
+      case '>':
+        return item[field] > parseFloat(value);
+      case '=':
+        return item[field] === value;
+      default:
+        return false; // Unsupported operator
+    }
+  });
+
+  // Limit the number of rows based on the rowCount parameter
+  const selectedData = filteredData.slice(0, rowCount);
+
+  // Select the specified fields from the filtered data
+  const result = selectedData.map((item) => {
+    const selectedFields = {};
+    select.forEach((fieldName) => {
+      selectedFields[fieldName] = item[fieldName];
+    });
+    return selectedFields;
+  });
+
+  return result;
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -15,6 +15,8 @@ import {
   isInternalPage,
 } from './lib-franklin.js';
 
+import query from './json-query.js';
+
 const LCP_BLOCKS = [
   'hero',
   'hero-banner',
@@ -332,6 +334,10 @@ export async function fetchIndex(indexFile, sheet, pageSize = 500) {
   return newIndex;
 }
 
+export function queryIndex(index, select, where, orderBy, rowCount) {
+  const result = query(select, index.data, where, orderBy, rowCount);
+  return result;
+}
 /**
  * Loads everything that happens a lot later,
  * without impacting the user experience.


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #9 

Seeking early feedback on this (currently DRAFT) PR for adding a generic querying mechanism for index. 
Sunstar site uses article feeds heavily at many places wherein the feeds have filtering criteria (like related, featured, recent, category etc.) where this may be useful. 

Test URLs:
- Before: https://main--sunstar--hlxsites.hlx.page/
- After: https://i-9--sunstar--hlxsites.hlx.page/

- [ ]  If you are adding a new block or a variation to an existing block, has it been added in the [block-library](https://adobe.sharepoint.com/:x:/r/sites/HelixProjects/Shared%20Documents/sites/sunstar/sunstar/sidekick/library.xlsx?d=w7f8a415fe192444caa87806b565bb62d&csf=1&web=1&e=oJWCS0) ?
