### PR TITLE
Revert "Updates to index for career testimonials"

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -51,13 +51,3 @@ indices:
         select: head > meta[property="article:tag"]
         values: |
           attribute(el, 'content')
-      career-image:
-        select: main .career-hero-photo img
-        value: attribute(el, "src")
-      career-quote:
-        select: main blockquote.career-hero-quote
-        value: textContent(el)
-      career-jobtitle:
-        select: main p.career-hero-title
-        value: textContent(el)
-


### PR DESCRIPTION
Reverting this commit because it turned out that the approach doesn't work.

Reverts hlxsites/sunstar#54

Test URLs:

* Before: https://main--sunstar--hlxsites.hlx.page/
* After: https://revert-54-issue-17_idx--sunstar--hlxsites.hlx.page/
