### PR TITLE
Autoblock image followed by cursive text into image-collage with 1 col

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -99,6 +99,118 @@ function buildModalFragmentBlock(main) {
   }
 }
 
+function indexOfElementInParent(element) {
+  return [...element.parentElement.children].indexOf(element);
+}
+
+/**
+ * Split children of this div up into 1, 2 or 3 separate divs with cut points as specified in
+ * the from and to indexes, separating the elements from-to into
+ * a separate div on the same level and putting the remaining elements in new divs surrounding it.
+ * @param {HTMLElement} div The element to work on.
+ * @param {number} from The index from from which to put element into the middle div.
+ * @param {number} to The index up-to-but-not-including the element that marks then end of the
+ * middle div.
+ * @returns Returns the middle div.
+ */
+function splitChildDiv(div, from, to) {
+  // run backwards because moving element will delete them from the original
+
+  let afterDiv;
+  if (to < div.children.length - 1) {
+    afterDiv = document.createElement('div');
+    for (let i = div.children.length - 1; i >= to; i -= 1) {
+      afterDiv.prepend(div.children[i]);
+    }
+  }
+
+  const midDiv = document.createElement('div');
+  for (let i = to - 1; i >= from; i -= 1) {
+    midDiv.prepend(div.children[i]);
+  }
+
+  let beforeDiv;
+  if (from > 0) {
+    beforeDiv = document.createElement('div');
+    for (let i = from - 1; i >= 0; i -= 1) {
+      beforeDiv.prepend(div.children[i]);
+    }
+  }
+
+  if (beforeDiv) {
+    div.parentElement.insertBefore(beforeDiv, div);
+  }
+  div.parentElement.insertBefore(midDiv, div);
+  if (afterDiv) {
+    div.parentElement.insertBefore(afterDiv, div);
+  }
+  div.parentElement.removeChild(div);
+
+  return midDiv;
+}
+
+function buildImageCollageForPicture(picture, caption, buildBlockFunction) {
+  const newBlock = buildBlockFunction('image-collage', { elems: [picture, caption] });
+  newBlock.classList.add('boxy-col-1');
+  return newBlock;
+}
+
+function buildImageWithCaptionForPicture(parentP, picture, buildBlockFunction) {
+  const enclosingDiv = parentP.parentElement;
+  if (enclosingDiv) {
+    // The caption could either be right next to the picture (if on the same line)
+    // or it could be in an adjacent sibling element (if 'enter' was pressed between)
+    const captionP = [
+      picture.nextElementSibling,
+      parentP.nextElementSibling,
+    ];
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const cp of captionP) {
+      if (!cp) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      if (cp.localName === 'em') {
+        // It's on the same line
+        enclosingDiv.append(buildImageCollageForPicture(picture, cp, buildBlockFunction));
+        return;
+      }
+
+      // Maybe the 'em' is on the next line, which means its in a separate <p> element
+      let hasEMChild = false;
+      // eslint-disable-next-line no-restricted-syntax
+      for (const c of cp.children) {
+        if (c.localName === 'em') {
+          hasEMChild = true;
+          break;
+        }
+      }
+
+      if (hasEMChild) {
+        const idx = indexOfElementInParent(parentP);
+        const section = splitChildDiv(enclosingDiv, idx, idx + 2);
+        section.append(buildImageCollageForPicture(parentP, cp, buildBlockFunction));
+        return;
+      }
+    }
+  }
+}
+
+export function buildImageWithCaptionBlocks(main, buildBlockFunction) {
+  // Find blocks that contain a picture followed by an em text block. These are
+  // single-column image collage blocks (with a caption)
+  const pictures = main.querySelectorAll('picture');
+
+  pictures.forEach((p) => {
+    const parentP = p.parentElement;
+    if (parentP) {
+      buildImageWithCaptionForPicture(parentP, p, buildBlockFunction);
+    }
+  });
+}
+
 /**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
@@ -107,6 +219,7 @@ function buildAutoBlocks(main) {
   try {
     buildHeroBlock(main);
     buildModalFragmentBlock(main);
+    buildImageWithCaptionBlocks(main, buildBlock);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -113,7 +113,7 @@ function indexOfElementInParent(element) {
  * middle div.
  * @returns Returns the middle div.
  */
-function splitChildDiv(div, from, to) {
+export function splitChildDiv(div, from, to) {
   // run backwards because moving element will delete them from the original
 
   let afterDiv;


### PR DESCRIPTION
When an image is followed by cursive text, this combination with be auto-blocked into an image-collage with 1 column for an Image with a caption.

The caption can either follow the image directly:
<img width="236" alt="Screenshot 2023-10-02 at 14 23 13" src="https://github.com/hlxsites/sunstar/assets/226514/34909c0e-9eef-40c0-b8be-0249a0592d3d">

or it can follow the image on the next line:
<img width="151" alt="Screenshot 2023-10-02 at 14 23 05" src="https://github.com/hlxsites/sunstar/assets/226514/d243166f-8681-4aaa-97ec-69c7a6230f56">

The result will be an `image-collage` block with the `boxy-col-1` style
<img width="844" alt="Screenshot 2023-10-02 at 14 25 15" src="https://github.com/hlxsites/sunstar/assets/226514/283fa674-78c2-4a0b-a762-632a7bd3bba3">

Contributes to #85

Test URLs (see bottom for example):
- Origina: https://www.sunstar.com/career/boedi-hartono/
- Before: https://main--sunstar--hlxsites.hlx.live/career/boedi-hartono
- After: https://issue-85--sunstar--hlxsites.hlx.live/career/boedi-hartono
