### PR TITLE
Redirection added for news and healthy thinking pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
 <head>
   <title>Page not found</title>
   <script type="text/javascript">
@@ -39,7 +38,6 @@
     if (healthifyThinkingRegex.test(windowHref)) {
 			window.stop(); // Stop processing this page, make sure no 404 rendering is done
       const newLoc = windowHref.replaceAll(/healthy-thinking\/(category)\//g, 'healthy-thinking/');
-			console.log(newLoc);
 			window.location.replace(newLoc);
     }
 

--- a/404.html
+++ b/404.html
@@ -24,6 +24,25 @@
       window.location.replace(newLoc);
     }
 
+		/**
+		* * Redirecting all newsroom pages and healthy thinking pages
+		*/
+		const windowHref = window.location.href;
+    const newsRegex = /newsroom\/(event|news|press-releases)/;
+    if (newsRegex.test(windowHref)) {
+			window.stop(); // Stop processing this page, make sure no 404 rendering is done
+      const newLoc = windowHref.replaceAll(/newsroom\/(event|news|press-releases)\//g, 'newsroom/');
+			window.location.replace(newLoc);
+    }
+
+    const healthifyThinkingRegex = /healthy-thinking\/(category)/;
+    if (healthifyThinkingRegex.test(windowHref)) {
+			window.stop(); // Stop processing this page, make sure no 404 rendering is done
+      const newLoc = windowHref.replaceAll(/healthy-thinking\/(category)\//g, 'healthy-thinking/');
+			console.log(newLoc);
+			window.location.replace(newLoc);
+    }
+
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="Page not found">

--- a/tools/importer/import-news-press-healthythinking.js
+++ b/tools/importer/import-news-press-healthythinking.js
@@ -140,7 +140,7 @@ const addQuoteBlock = (document) => {
 const changeAnchorLinks = (document) => {
   const anchors = document.querySelectorAll('a');
   [...anchors].forEach((item) => {
-    const newsRegex = /newsroom\/(news|press-releases)/;
+    const newsRegex = /newsroom\/(event|news|press-releases)/;
     if (newsRegex.test(item.href)) {
       item.href = item.href.replaceAll(/newsroom\/(event|news|press-releases)\//g, 'newsroom/');
     }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #94 

Test URLs:
- Original: https://www.sunstar.com
- Before: https://main--sunstar--hlxsites.hlx.live
- After: https://redirection--sunstar--hlxsites.hlx.live


- [ ]  **If you are adding a new block or a variation to an existing block**, please fill below:

  Block library path: https://<branch>--sunstar--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/<your-block>&index=0
