### PR TITLE
Update indexing to use hero-career instead of career-hero

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -55,8 +55,8 @@ indices:
         select: head > meta[property="og:image"]
         value: attribute(el, "content")
       career-quote:
-        select: main .career-hero
+        select: main .hero-career
         value: match(el, '.*?\n?Quote\n([^\n]+)')
       career-jobtitle:
-        select: main .career-hero
+        select: main .hero-career
         value: match(el, '.*?\n?Title\n([^\n]+)')


### PR DESCRIPTION
Contributes towards #85

Test URLs:
- Original: https://www.sunstar.com/career/boedi-hartono
- Before: https://main--sunstar--hlxsites.hlx.live/career/boedi-hartono
- After: https://issue-85-3--sunstar--hlxsites.hlx.live/career/boedi-hartono
