### PR TITLE
Add left padding to hero-banner text

### DIFF
--- a/blocks/hero-banner/hero-banner.css
+++ b/blocks/hero-banner/hero-banner.css
@@ -160,6 +160,7 @@
         flex-basis: calc(100% - 11.625rem);
         margin-bottom: unset;
         width: unset;
+        padding-left: 2rem;
     }
 
     .hero-banner .hero-banner-button-container a.button.primary {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #<gh-issue-id>

Test URLs:
- Original: https://www.sunstar.com
- Before: https://main--sunstar--hlxsites.hlx.live
- After: https://hb-padding--sunstar--hlxsites.hlx.live

Before:
![image](https://github.com/hlxsites/sunstar/assets/1191451/fcab8669-c248-4a37-8096-56c5fae10d8a)

After:
![image](https://github.com/hlxsites/sunstar/assets/1191451/e2f1071d-467f-45dd-87ae-3ba4c21cf5a1)


- [ ]  **If you are adding a new block or a variation to an existing block**, please fill below:

  Block library path: https://<branch>--sunstar--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/<your-block>&index=0
