### PR TITLE
PDF behaviour opening behaviour changed and icon change

### DIFF
--- a/blocks/social/social.css
+++ b/blocks/social/social.css
@@ -94,6 +94,11 @@ main .section.social-container p {
   width: 1.5rem;
 }
 
+main .section.social-container .icon-link-blue {
+  height: 1.25rem;
+  width: 1.25rem;
+}
+
 .block.social .icon-twitter {
   background-image: url("../../icons/twitter.svg");
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -262,6 +262,25 @@ export function decorateExternalAnchors(externalAnchors) {
 }
 
 /**
+ * Gets the extension of a URL.
+ * @param {string} url The URL
+ * @returns {string} The extension
+ * @private
+ * @example
+ * get_url_extension('https://example.com/foo.jpg');
+ * // returns 'jpg'
+ * get_url_extension('https://example.com/foo.jpg?bar=baz');
+ * // returns 'jpg'
+ * get_url_extension('https://example.com/foo');
+ * // returns ''
+ * get_url_extension('https://example.com/foo.jpg#qux');
+ * // returns 'jpg'
+ */
+function getUrlExtension(url) {
+  return url.split(/[#?]/)[0].split('.').pop().trim();
+}
+
+/**
  * decorates anchors
  * for styling updates via CSS
  * @param {Element} element The element to decorate
@@ -273,7 +292,8 @@ export function decorateAnchors(element = document) {
     (a) => a.href.includes('youtu'),
   ));
   decorateExternalAnchors(Array.from(anchors).filter(
-    (a) => a.href && !a.href.match(`^http[s]*://${window.location.host}/`),
+    (a) => a.href && (!a.href.match(`^http[s]*://${window.location.host}/`)
+    || ['pdf'].includes(getUrlExtension(a.href).toLowerCase())),
   ));
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes

Test URLs:
- Original: https://www.sunstar.com/healthy-thinking/global-healthy-thinking-report-2021
- Before: https://main--sunstar--hlxsites.hlx.live/healthy-thinking/global-healthy-thinking-report-2021
- After: https://icon-change--sunstar--hlxsites.hlx.live/healthy-thinking/global-healthy-thinking-report-2021


- [ ]  **If you are adding a new block or a variation to an existing block**, please fill below:

  Block library path: https://<branch>--sunstar--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/<your-block>&index=0
