### PR TITLE
Global top spacing

### DIFF
--- a/.github/workflows/visual-tests.yaml
+++ b/.github/workflows/visual-tests.yaml
@@ -5,7 +5,7 @@ on:
     types: [ opened, synchronize ]
 
 env:
-  TEST_PATHS: "/ /career/yuya-yoshisue /brands/consumer-health-beauty /healthy-thinking/6-things-you-didnt-know-about-your-oral-health /brands /about/history /about/business-performance /about/structure /sustainability"
+  TEST_PATHS: "/ /career/yuya-yoshisue /brands/consumer-health-beauty /healthy-thinking/6-things-you-didnt-know-about-your-oral-health /brands /about/history /about/business-performance /about/structure /sustainability /careers/career-opportunities /about/global-network"
   TEST_PATHS_INDEXES: "/sidekick/library.json "
   DOMAIN_MAIN: "main--sunstar--hlxsites.hlx.page"
   DOMAIN_BRANCH: "${{github.head_ref}}--sunstar--hlxsites.hlx.page"

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -35,7 +35,7 @@ export const MODAL_FRAGMENTS_ANCHOR_SELECTOR = `a[href*="${MODAL_FRAGMENTS_PATH_
 
 let language;
 
-const lastPossibleTopSpacingSectionIndex = 3;
+const LAST_POSSIBLE_TOP_SPACING_SECTION = 3;
 
 export function getLanguageFromPath(pathname, resetCache = false) {
   if (resetCache) {
@@ -319,7 +319,7 @@ export function addTopSpacingStyleToFirstMatchingSection(main) {
   let added = false;
 
   sections.every((section) => {
-    if (added || sections.indexOf(section) === lastPossibleTopSpacingSectionIndex) return false;
+    if (added || sections.indexOf(section) === LAST_POSSIBLE_TOP_SPACING_SECTION) return false;
     const sectionClasses = [...section.classList];
     const matchesExcluded = excludedClasses.filter((excluded) => sectionClasses.includes(excluded));
     const incompatible = matchesExcluded.length > 0;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -310,6 +310,26 @@ export function getWindowSize() {
     height: windowHeight,
   };
 }
+
+export function addTopSpacingStyleToFirstMatchingSection(main) {
+  const excludedClasses = ['static', 'feed-container', 'modal-fragment-container', 'hero-banner-container', 'hero-career-container', 'breadcrumb-container', 'hero-horizontal-tabs-container', 'carousel-container'];
+  const sections = [...main.querySelectorAll(':scope > div')];
+  let added = false;
+
+  sections.every((section) => {
+    if (added || sections.indexOf(section) >= 2) return false;
+    const sectionClasses = [...section.classList];
+    const matchesExcluded = excludedClasses.filter((excluded) => sectionClasses.includes(excluded));
+    const incompatible = matchesExcluded.length > 0;
+    if (!incompatible) {
+      section.classList.add('auto-top-spacing');
+      added = true;
+      return false;
+    }
+    return true;
+  });
+}
+
 /**
  * Decorates the main element.
  * @param {Element} main The main element
@@ -323,6 +343,7 @@ export function decorateMain(main) {
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
+  addTopSpacingStyleToFirstMatchingSection(main);
 }
 
 function decoratePageStyles() {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -317,7 +317,7 @@ export function addTopSpacingStyleToFirstMatchingSection(main) {
   let added = false;
 
   sections.every((section) => {
-    if (added || sections.indexOf(section) >= 2) return false;
+    if (added || sections.indexOf(section) >= 3) return false;
     const sectionClasses = [...section.classList];
     const matchesExcluded = excludedClasses.filter((excluded) => sectionClasses.includes(excluded));
     const incompatible = matchesExcluded.length > 0;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -312,7 +312,7 @@ export function getWindowSize() {
 }
 
 export function addTopSpacingStyleToFirstMatchingSection(main) {
-  const excludedClasses = ['static', 'feed-container', 'modal-fragment-container', 'hero-banner-container', 'hero-career-container', 'breadcrumb-container', 'hero-horizontal-tabs-container', 'carousel-container'];
+  const excludedClasses = ['static', 'spacer-container', 'feed-container', 'modal-fragment-container', 'hero-banner-container', 'hero-career-container', 'breadcrumb-container', 'hero-horizontal-tabs-container', 'carousel-container'];
   const sections = [...main.querySelectorAll(':scope > div')];
   let added = false;
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -35,6 +35,8 @@ export const MODAL_FRAGMENTS_ANCHOR_SELECTOR = `a[href*="${MODAL_FRAGMENTS_PATH_
 
 let language;
 
+// search for at most these many sections to find the first one that can have top spacing
+// ideally the first section would get the top spacing, but breadcrumb, hero etc do not get spacing
 const LAST_POSSIBLE_TOP_SPACING_SECTION = 3;
 
 export function getLanguageFromPath(pathname, resetCache = false) {
@@ -313,6 +315,13 @@ export function getWindowSize() {
   };
 }
 
+/**
+ * We look for the first section that does not contain any of the excluded classes
+ * and add the auto-top-spacing class to it.
+ *
+ * Once we find this section, OR we reach the LAST_POSSIBLE_TOP_SPACING_SECTION (=== 3)
+ * we break out of the loop to not add spacing to other sections as well.
+ */
 export function addTopSpacingStyleToFirstMatchingSection(main) {
   const excludedClasses = ['static', 'spacer-container', 'feed-container', 'modal-fragment-container', 'hero-banner-container', 'hero-career-container', 'breadcrumb-container', 'hero-horizontal-tabs-container', 'carousel-container'];
   const sections = [...main.querySelectorAll(':scope > div')];

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -35,6 +35,8 @@ export const MODAL_FRAGMENTS_ANCHOR_SELECTOR = `a[href*="${MODAL_FRAGMENTS_PATH_
 
 let language;
 
+const lastPossibleTopSpacingSectionIndex = 3;
+
 export function getLanguageFromPath(pathname, resetCache = false) {
   if (resetCache) {
     language = undefined;
@@ -317,7 +319,7 @@ export function addTopSpacingStyleToFirstMatchingSection(main) {
   let added = false;
 
   sections.every((section) => {
-    if (added || sections.indexOf(section) >= 3) return false;
+    if (added || sections.indexOf(section) === lastPossibleTopSpacingSectionIndex) return false;
     const sectionClasses = [...section.classList];
     const matchesExcluded = excludedClasses.filter((excluded) => sectionClasses.includes(excluded));
     const incompatible = matchesExcluded.length > 0;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-
 :root {
   /* colors */
   --black: #000;
@@ -463,6 +462,11 @@ main img {
 
 /* START Section Styles START */
 
+main .section:not(.breadcrumb-container, .hero-horizontal-tabs-container, .carousel-container):first-of-type > div.section-container,
+main .section:not(.breadcrumb-container, .hero-horizontal-tabs-container, .carousel-container):nth-of-type(2) > div.section-container {
+  margin-top: 3rem;
+}
+
 main .section .section-container {
   max-width: 100%;
   padding-left: 0;
@@ -809,6 +813,7 @@ main .section.thank-you {
   margin: 64px auto 120px;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 main .section.thank-you div.section-container {
   padding: 0 16px;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -462,16 +462,14 @@ main img {
 
 /* START Section Styles START */
 
-main .section:not(.static, .modal-fragment-container, .hero-banner-container, .hero-career-container, .breadcrumb-container, .hero-horizontal-tabs-container, .carousel-container):first-of-type > div.section-container,
-main .section:not(.static, .modal-fragment-container, .hero-banner-container, .hero-career-container, .breadcrumb-container, .hero-horizontal-tabs-container, .carousel-container):nth-of-type(2) > div.section-container,
-main .section:not(.static, .modal-fragment-container, .hero-banner-container, .hero-career-container, .breadcrumb-container, .hero-horizontal-tabs-container, .carousel-container):nth-of-type(3) > div.section-container {
-  margin-top: 3rem;
-}
-
 main .section .section-container {
   max-width: 100%;
   padding-left: 0;
   padding-right: 0;
+}
+
+main .section.auto-top-spacing .section-container {
+  margin-top: 3rem;
 }
 
 /* section - bold headings */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -462,8 +462,9 @@ main img {
 
 /* START Section Styles START */
 
-main .section:not(.breadcrumb-container, .hero-horizontal-tabs-container, .carousel-container):first-of-type > div.section-container,
-main .section:not(.breadcrumb-container, .hero-horizontal-tabs-container, .carousel-container):nth-of-type(2) > div.section-container {
+main .section:not(.static, .modal-fragment-container, .hero-banner-container, .hero-career-container, .breadcrumb-container, .hero-horizontal-tabs-container, .carousel-container):first-of-type > div.section-container,
+main .section:not(.static, .modal-fragment-container, .hero-banner-container, .hero-career-container, .breadcrumb-container, .hero-horizontal-tabs-container, .carousel-container):nth-of-type(2) > div.section-container,
+main .section:not(.static, .modal-fragment-container, .hero-banner-container, .hero-career-container, .breadcrumb-container, .hero-horizontal-tabs-container, .carousel-container):nth-of-type(3) > div.section-container {
   margin-top: 3rem;
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -812,7 +812,6 @@ main .section.thank-you {
   margin: 64px auto 120px;
 }
 
-/* stylelint-disable-next-line no-descending-specificity */
 main .section.thank-you div.section-container {
   padding: 0 16px;
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #159 

- Implemented "autoblocking" the first section that is not a hero, carousel etc (basically anything that has a colored background) to have a `3rem` padding at the top; aka there should now be some spacing between the breadcrumb and content on a page
- Usually the first section will be the `breadcrumb` section; followed by either an `excluded` block (hero,carousel etc) or the content that should get the top spacing
- There's some edge cases such as  `spacer` blocks and `modal + tabs` combinations that require looking at the 3rd section as well

Example affected page:
- After: https://global-top-spacing--sunstar--hlxsites.hlx.page/about/business-performance
- Before: https://main--sunstar--hlxsites.hlx.page/about/business-performance

Example not affected page:
- After: https://global-top-spacing--sunstar--hlxsites.hlx.page/careers/career-opportunities
- Before: https://main--sunstar--hlxsites.hlx.page/careers/career-opportunities

Test URLs:
- Original: https://www.sunstar.com/<path>
- Before: https://main--sunstar--hlxsites.hlx.live/<path>
- After: https://global-top-spacing--sunstar--hlxsites.hlx.live/<path>


- [ ]  **If you are adding a new block or a variation to an existing block**, please fill below:

  Block library path: https://<branch>--sunstar--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/<your-block>&index=0
