### PR TITLE
Mask the career carousel from the visual test screenshots

### DIFF
--- a/.github/visual-tests/compare.spec.ts
+++ b/.github/visual-tests/compare.spec.ts
@@ -59,7 +59,10 @@ async function loadAndScreenshot(page: Page, url: string, testPath: string, suff
 
   return await page.screenshot({
     path: getScreenshotPath(testPath, suffix),
-    fullPage: true
+    fullPage: true,
+
+    // The career carousel is shuffled so exclude from the compare
+    mask: [page.locator('div.career-carousel > div.career-slider')]
   });
 }
 


### PR DESCRIPTION
The order in the career carousel is shuffled, so that will cause problems with the visual tests. This change will mask these elements out of the comparison.

Test URLs:
- Before: https://main--sunstar--hlxsites.hlx.live/career/mohamad-amir-rahman
- After: https://visual-test-masking--sunstar--hlxsites.hlx.live/career/mohamad-amir-rahman

