### PR TITLE
Add Card Carousel block that also support career carousel as a variant

### DIFF
--- a/blocks/card-carousel/card-carousel.css
+++ b/blocks/card-carousel/card-carousel.css
@@ -1,0 +1,195 @@
+.card-carousel {
+  --card-width: 16rem;
+
+  margin-top: 3rem;
+  padding-left: 0.5rem;
+}
+
+.career-slider {
+  display: flex;
+  flex-direction: column;
+  margin-left: 12rem;
+}
+
+.career-slides {
+  display: flex;
+  overflow-x: scroll;
+  scroll-behavior: smooth;
+
+  /* We want to hide the scroll bar */
+  -ms-overflow-style: none; /* for Internet Explorer, Edge */
+  scrollbar-width: none; /* for Firefox */
+}
+
+/* Hide the scroll bar */
+.career-slides::-webkit-scrollbar {
+  /* for Chrome, Safari and Opera */
+  display: none;
+}
+
+.card-carousel .career-card {
+  flex-shrink: 0;
+  box-shadow: #3c465040 0 2px 12px 0;
+  margin: 1.5rem 3.5rem;
+  /*padding: 1rem;*/
+  width: 20rem;
+  transition: all 0.15s ease-in-out;
+}
+
+.card-carousel .career-card:hover {
+  box-shadow: #3c465066 0 4px 16px 0;
+}
+
+.card-carousel .career-card a {
+  display: inline-flex;
+  flex-direction: column;
+  text-decoration: none;
+}
+
+.card-carousel .career-card a > div:nth-child(2) {
+  margin: 2rem 1rem;
+}
+
+.card-carousel .career-card picture {
+  align-self: center;
+  width: 14.375rem;
+  margin: 0 0 1.375rem;
+}
+
+.card-carousel .career-card picture img {
+  height: 9.5625rem;
+  width: 8.75rem;
+  padding-inline: 2.8rem;
+}
+
+.card-carousel .career-card blockquote {
+  color: var(--primary);
+  font-size: var(--body-font-size-m);
+  font-style: normal;
+  line-height: 24px;
+  margin: 0 0 19px;
+  max-height: 8rem;
+  overflow: hidden;
+  text-indent: 0;
+
+  /* Show ellipsis on multiline text */
+  display: -webkit-box;
+  -webkit-line-clamp: 5; /* number of lines to show */
+  -webkit-box-orient: vertical;
+}
+
+.card-carousel .career-card .career-card-bqc {
+  height: 8rem;
+  margin-bottom: 0.75rem;
+}
+
+.card-carousel .career-card h6 {
+  color: var(--light-black);
+  font-size: var( --heading-font-size-mxs);
+  text-transform: none;
+  margin-bottom: 6px;
+}
+
+.card-carousel .career-card p {
+  color: var(--light-black);
+  font-size: var(--body-font-size-s);
+  height: 2.5rem;
+  line-height: 21.6px;
+  margin-bottom: 0.75rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.card-carousel .career-card button {
+  background-color: unset;
+  color: var(--secondary);
+  font-family: var(--body-font-family);
+  font-size: var(--body-font-size-m);
+  font-weight: var(--font-weight-medium);
+  justify-content: left;
+  height: auto;
+  padding: 0;
+  margin-block: 1rem;
+}
+
+.card-carousel .career-card button:hover {
+  text-decoration: underline;
+}
+
+.card-carousel .career-card button .icon-angle-right-blue {
+  height: 14px;
+  width: 10px;
+  margin-left: 6px;
+  margin-top: 2px;
+}
+
+.card-carousel .career-slides-navbar {
+  display: none;
+  margin-top: -0.5rem;
+  overflow-x: hidden;
+}
+
+.card-carousel .career-slides-nav {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 3.125rem;
+  margin-bottom: 2.5rem;
+  margin-left: calc(50% - 4rem);
+}
+
+.card-carousel .career-slides-nav span {
+  width: 6px;
+  height: 6px;
+  margin: 0 3px;
+  border-radius: 50%;
+  background: #0003;
+}
+
+.card-carousel .career-slides-nav span.active-nav {
+  background: var(--link-color);
+}
+
+.card-carousel .career-slides-nav .btn-angle {
+  height: 1.5rem;
+  width: 1rem;
+  margin-inline: 0.5rem;
+}
+
+@media (min-width: 77rem) {
+  .career-slider {
+    width: calc(((var(--card-width) + 4rem) * 4));
+  }
+
+  .card-carousel .career-card blockquote {
+    font-size: var(--body-font-size-l);
+    line-height: 29px;
+    max-height: 9.375rem;
+  }
+
+  .card-carousel .career-card .career-card-bqc {
+    height: 9.375rem;
+  }
+
+  .card-carousel .career-card picture img {
+    height: 16rem;
+    width: 30rem;
+    padding-inline: 0;
+  }
+
+  .card-carousel .career-slides-navbar {
+    display: flex;
+  }
+}
+
+.cards-card-image {
+  height: 12.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.cards-card-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: 50% 0%;
+}

--- a/blocks/card-carousel/card-carousel.css
+++ b/blocks/card-carousel/card-carousel.css
@@ -5,10 +5,9 @@
   padding-left: 0.5rem;
 }
 
-.career-slider {
+.card-slider {
   display: flex;
   flex-direction: column;
-  margin-left: 12rem;
 }
 
 .cards-card-image {
@@ -17,11 +16,11 @@
   padding: 0;
 }
 
-.career .career-slider{
+.career .card-slider{
   margin-left: -1rem;
 }
 
-.career-slides {
+.card-slides {
   display: flex;
   overflow-x: scroll;
   scroll-behavior: smooth;
@@ -32,27 +31,27 @@
 }
 
 /* Hide the scroll bar */
-.career-slides::-webkit-scrollbar {
+.card-slides::-webkit-scrollbar {
   /* for Chrome, Safari and Opera */
   display: none;
 }
 
-.card-carousel .career-card {
+.card-carousel .carousel-childcard {
   flex-shrink: 0;
-  box-shadow: #3c465040 0 2px 12px 0;
-  margin: 1.5rem 3.5rem;
-  width: 20rem;
+  box-shadow: var(--light-grey) 0 2px 12px 0;
+  margin: 1.5rem 3.5px;
+  width: 15rem;
   transition: all 0.15s ease-in-out;
 }
 
-.card-carousel.career .career-card {
+.card-carousel.career .carousel-childcard {
   margin: 1.5rem 0.5rem;
   padding: 1rem;
   width: var(--card-width);
 }
 
 .card-carousel .career-card:hover {
-  box-shadow: #3c465066 0 4px 16px 0;
+  box-shadow: var(--light-grey) 0 4px 16px 0;
 }
 
 .cards-card-image img {
@@ -62,37 +61,37 @@
   object-position: 50% 0%;
 }
 
-.card-carousel .career-card a {
+.card-carousel .carousel-childcard a {
   display: inline-flex;
   flex-direction: column;
   text-decoration: none;
 }
 
-.card-carousel .career-card a > div:nth-child(2) {
+.card-carousel .carousel-childcard a > div:nth-child(2) {
   margin: 2rem 1rem;
 }
 
-.card-carousel.career .career-card a > div:nth-child(2) {
+.card-carousel.career .carousel-childcard a > div:nth-child(2) {
   margin: 0;
 }
 
-card-carousel.career .career-card a > :not(picture) {
+.card-carousel.career .carousel-childcard a > :not(picture) {
   width: 100%;
 }
 
-.card-carousel .career-card picture {
+.card-carousel .carousel-childcard picture {
   align-self: center;
   width: 14.375rem;
   margin: 0 0 1.375rem;
 }
 
-.card-carousel .career-card picture img {
-  height: 9.5625rem;
+.card-carousel .carousel-childcard picture img {
+  height: 9.5rem;
   width: 8.75rem;
   padding-inline: 2.8rem;
 }
 
-.card-carousel .career-card blockquote {
+.card-carousel .carousel-childcard blockquote {
   color: var(--primary);
   font-size: var(--body-font-size-m);
   font-style: normal;
@@ -108,19 +107,19 @@ card-carousel.career .career-card a > :not(picture) {
   -webkit-box-orient: vertical;
 }
 
-.card-carousel .career-card .career-card-bqc {
+.card-carousel .carousel-childcard .career-card-bqc {
   height: 8rem;
   margin-bottom: 0.75rem;
 }
 
-.card-carousel .career-card h6 {
+.card-carousel .carousel-childcard h6 {
   color: var(--light-black);
   font-size: var( --heading-font-size-mxs);
   text-transform: none;
   margin-bottom: 6px;
 }
 
-.card-carousel .career-card p {
+.card-carousel .carousel-childcard p {
   color: var(--light-black);
   font-size: var(--body-font-size-s);
   height: 2.5rem;
@@ -130,7 +129,7 @@ card-carousel.career .career-card a > :not(picture) {
   text-overflow: ellipsis;
 }
 
-.card-carousel .career-card button {
+.card-carousel .carousel-childcard button {
   background-color: unset;
   color: var(--secondary);
   font-family: var(--body-font-family);
@@ -142,24 +141,24 @@ card-carousel.career .career-card a > :not(picture) {
   margin-block: 1rem;
 }
 
-.card-carousel .career-card button:hover {
+.card-carousel .carousel-childcard button:hover {
   text-decoration: underline;
 }
 
-.card-carousel .career-card button .icon-angle-right-blue {
+.card-carousel .carousel-childcard button .icon-angle-right-blue {
   height: 14px;
   width: 10px;
   margin-left: 6px;
   margin-top: 2px;
 }
 
-.card-carousel .career-slides-navbar {
+.card-carousel .card-slides-navbar {
   display: none;
   margin-top: -0.5rem;
   overflow-x: hidden;
 }
 
-.card-carousel .career-slides-nav {
+.card-carousel .card-slides-nav {
   display: inline-flex;
   align-items: center;
   margin-top: 3.125rem;
@@ -167,7 +166,7 @@ card-carousel.career .career-card a > :not(picture) {
   margin-left: calc(50% - 4rem);
 }
 
-.card-carousel .career-slides-nav span {
+.card-carousel .card-slides-nav span {
   width: 6px;
   height: 6px;
   margin: 0 3px;
@@ -175,46 +174,52 @@ card-carousel.career .career-card a > :not(picture) {
   background: #0003;
 }
 
-.card-carousel .career-slides-nav span.active-nav {
+.card-carousel .card-slides-nav span.active-nav {
   background: var(--link-color);
 }
 
-.card-carousel .career-slides-nav .btn-angle {
+.card-carousel .card-slides-nav .btn-angle {
   height: 1.5rem;
   width: 1rem;
   margin-inline: 0.5rem;
 }
 
 @media (min-width: 77rem) {
-  .career-slider {
+  .card-slider {
     width: calc(((var(--card-width) + 4rem) * 4));
+    margin-left: 12rem;
   }
 
-  .career .career-slider{
+  .career .card-slider{
     width: calc(((var(--card-width) + 3rem) * 4));
   }
 
-  .card-carousel .career-card blockquote {
+  .card-carousel .carousel-childcard {
+    margin: 1.5rem 3.5rem;
+    width: 20rem;
+  }
+
+  .card-carousel .carousel-childcard blockquote {
     font-size: var(--body-font-size-l);
     line-height: 29px;
     max-height: 9.375rem;
   }
 
-  .card-carousel .career-card .career-card-bqc {
+  .card-carousel .carousel-childcard .career-card-bqc {
     height: 9.375rem;
   }
 
-  .card-carousel .career-card picture img {
+  .card-carousel .carousel-childcard picture img {
     height: 16rem;
     width: 30rem;
     padding-inline: 0;
   }
 
-  .card-carousel.career .career-card picture img {
+  .card-carousel.career .carousel-childcard picture img {
     width: 14.375rem;
   }
 
-  .card-carousel .career-slides-navbar {
+  .card-carousel .card-slides-navbar {
     display: flex;
   }
 }

--- a/blocks/card-carousel/card-carousel.css
+++ b/blocks/card-carousel/card-carousel.css
@@ -11,6 +11,10 @@
   margin-left: 12rem;
 }
 
+.career .career-slider{
+  margin-left: -1rem;
+}
+
 .career-slides {
   display: flex;
   overflow-x: scroll;
@@ -31,9 +35,14 @@
   flex-shrink: 0;
   box-shadow: #3c465040 0 2px 12px 0;
   margin: 1.5rem 3.5rem;
-  /*padding: 1rem;*/
   width: 20rem;
   transition: all 0.15s ease-in-out;
+}
+
+.card-carousel.career .career-card {
+  margin: 1.5rem 0.5rem;
+  padding: 1rem;
+  width: var(--card-width);
 }
 
 .card-carousel .career-card:hover {
@@ -48,6 +57,14 @@
 
 .card-carousel .career-card a > div:nth-child(2) {
   margin: 2rem 1rem;
+}
+
+.card-carousel.career .career-card a > div:nth-child(2) {
+  margin: 0;
+}
+
+card-carousel.career .career-card a > :not(picture) {
+  width: 100%;
 }
 
 .card-carousel .career-card picture {
@@ -160,6 +177,10 @@
     width: calc(((var(--card-width) + 4rem) * 4));
   }
 
+  .career .career-slider{
+    width: calc(((var(--card-width) + 3rem) * 4));
+  }
+
   .card-carousel .career-card blockquote {
     font-size: var(--body-font-size-l);
     line-height: 29px;
@@ -174,6 +195,10 @@
     height: 16rem;
     width: 30rem;
     padding-inline: 0;
+  }
+
+  .card-carousel.career .career-card picture img {
+    width: 14.375rem;
   }
 
   .card-carousel .career-slides-navbar {

--- a/blocks/card-carousel/card-carousel.css
+++ b/blocks/card-carousel/card-carousel.css
@@ -11,6 +11,12 @@
   margin-left: 12rem;
 }
 
+.cards-card-image {
+  height: 12.5rem;
+  margin: 0;
+  padding: 0;
+}
+
 .career .career-slider{
   margin-left: -1rem;
 }
@@ -47,6 +53,13 @@
 
 .card-carousel .career-card:hover {
   box-shadow: #3c465066 0 4px 16px 0;
+}
+
+.cards-card-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: 50% 0%;
 }
 
 .card-carousel .career-card a {
@@ -204,17 +217,4 @@ card-carousel.career .career-card a > :not(picture) {
   .card-carousel .career-slides-navbar {
     display: flex;
   }
-}
-
-.cards-card-image {
-  height: 12.5rem;
-  margin: 0;
-  padding: 0;
-}
-
-.cards-card-image img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: 50% 0%;
 }

--- a/blocks/card-carousel/card-carousel.js
+++ b/blocks/card-carousel/card-carousel.js
@@ -68,7 +68,8 @@ export default async function decorate(block) {
       div.classList.add('career-card');
 
       const a = document.createElement('a');
-      a.href = '#'; //Todo populate the Link of the stories
+      //Todo populate the Link of the stories
+      a.href = '#'; 
       div.append(a);
       a.innerHTML = row.innerHTML;
 

--- a/blocks/card-carousel/card-carousel.js
+++ b/blocks/card-carousel/card-carousel.js
@@ -68,7 +68,7 @@ export default async function decorate(block) {
       div.classList.add('career-card');
 
       const a = document.createElement('a');
-      a.href = hrefVal || '#';
+      a.href = '#'; //Todo populate the Link of the stories
       div.append(a);
       a.innerHTML = row.innerHTML;
 

--- a/blocks/card-carousel/card-carousel.js
+++ b/blocks/card-carousel/card-carousel.js
@@ -62,7 +62,6 @@ export default async function decorate(block) {
 
   const slideDivs = [];
   if (block.children && block.children.length > 0) {
-
     MAX_BUTTONS = block.children.length - 2;
     [...block.children].forEach((row) => {
       const div = document.createElement('div');

--- a/blocks/card-carousel/card-carousel.js
+++ b/blocks/card-carousel/card-carousel.js
@@ -1,0 +1,174 @@
+import { createOptimizedPicture, fetchPlaceholders } from '../../scripts/lib-franklin.js';
+import { fetchIndex, getLanguage, shuffleArray } from '../../scripts/scripts.js';
+
+export function filterIncompleteEntries(json) {
+  return json.data.filter((e) => e.image !== '' && e['career-quote'] !== '0' && e['career-jobtitle'] !== '0');
+}
+
+export function scrollToCard(idx, card, precedingCard, slides, span, doc) {
+  const rect = card.getBoundingClientRect();
+
+  // set the style on the active button
+  const buttons = doc.querySelectorAll('.career-slides-nav span.active-nav');
+  buttons.forEach((b) => b.classList.remove('active-nav'));
+  span.classList.add('active-nav');
+
+  // Compute the gap to add to the location
+  let gap = 0;
+  if (precedingCard) {
+    const prevRect = precedingCard.getBoundingClientRect();
+    gap = rect.x - (prevRect.x + prevRect.width);
+  }
+
+  slides.scrollTo(idx * (rect.width + gap), slides.scrollHeight);
+}
+
+export function scrollToAdjacent(spans, slideDivs, slides, next, doc) {
+  const curActive = spans.findIndex((s) => s.classList.contains('active-nav'));
+  if (curActive === -1) {
+    return;
+  }
+
+  // compute the next active element, wrapping around on over- or underflow.
+  const newActive = (curActive + (next ? 1 : -1) + spans.length) % spans.length;
+  if (slideDivs.length <= newActive) {
+    return;
+  }
+
+  scrollToCard(
+    newActive,
+    slideDivs[newActive],
+    newActive > 0 ? slideDivs[newActive - 1] : null,
+    slides,
+    spans[newActive],
+    doc,
+  );
+}
+
+let MAX_BUTTONS = 10;
+export default async function decorate(block) {
+  const lang = getLanguage();
+  const placeholders = await fetchPlaceholders(lang);
+
+  const idxPrefix = lang === 'en' ? '' : `${lang}-`;
+  const json = await fetchIndex('query-index', `${idxPrefix}career-testimonials`);
+  const data = shuffleArray(filterIncompleteEntries(json));
+
+  const careerSlider = document.createElement('div');
+  careerSlider.classList.add('career-slider');
+
+  const careerSlides = document.createElement('div');
+  careerSlides.classList.add('career-slides');
+
+  const slideDivs = [];
+  if(block.children && block.children.length > 0){
+
+    MAX_BUTTONS = block.children.length - 2;
+    [...block.children].forEach((row) => {
+      const div = document.createElement('div');
+      div.classList.add('career-card');
+
+      const a = document.createElement('a');
+      a.href = "www.google.com";
+      div.append(a);
+      a.innerHTML = row.innerHTML;
+
+      careerSlides.append(div);
+      slideDivs.push(div);
+  });
+  }
+  else{
+  for (let i = 0; i < data.length; i += 1) {
+    const div = document.createElement('div');
+    div.classList.add('career-card');
+    const a = document.createElement('a');
+    a.href = data[i].path;
+    const pic = createOptimizedPicture(data[i].image, data[i].pagename);
+    a.append(pic);
+
+    const bqc = document.createElement('div');
+    bqc.classList.add('career-card-bqc');
+    const bq = document.createElement('blockquote');
+    bq.textContent = data[i]['career-quote'];
+    bqc.append(bq);
+    a.append(bqc);
+
+    const nm = document.createElement('h6');
+    nm.textContent = data[i].pagename;
+    a.append(nm);
+
+    const role = document.createElement('p');
+    role.textContent = data[i]['career-jobtitle'];
+    a.append(role);
+
+    const link = document.createElement('button');
+    link.textContent = placeholders['career-carousel-readmore'];
+    const arrow = document.createElement('img');
+    arrow.src = '/icons/angle-right-blue.svg';
+    arrow.alt = 'Go to testimonial';
+    arrow.classList.add('icon-angle-right-blue');
+    link.append(arrow);
+    a.append(link);
+    div.append(a);
+
+    careerSlides.append(div);
+    slideDivs.push(div);
+  }
+  }
+  careerSlider.append(careerSlides);
+
+  const navBar = document.createElement('div');
+  navBar.classList.add('career-slides-navbar');
+  const navButtons = document.createElement('div');
+  navButtons.classList.add('career-slides-nav');
+
+  const buttons = [];
+  for (let i = 0; i < data.length && i < MAX_BUTTONS; i += 1) {
+    const prevDiv = i > 0 ? slideDivs[i - 1] : null;
+
+    const s = document.createElement('span');
+    s.classList.toggle('active-nav', i === 0);
+    s.tabIndex = '-1';
+    s.onclick = () => scrollToCard(i, slideDivs[i], prevDiv, careerSlides, s, document);
+    navButtons.append(s);
+
+    buttons.push(s);
+  }
+  const la = document.createElement('img');
+  la.src = '/icons/angle-left-blue.svg';
+  la.alt = 'Previous person card';
+  la.classList.add('btn-angle');
+  la.onclick = () => scrollToAdjacent(buttons, slideDivs, careerSlides, false, document);
+  navButtons.prepend(la);
+
+  const ra = document.createElement('img');
+  ra.src = '/icons/angle-right-blue.svg';
+  ra.alt = 'Next person card';
+  ra.classList.add('btn-angle');
+  ra.onclick = () => scrollToAdjacent(buttons, slideDivs, careerSlides, true, document);
+  navButtons.append(ra);
+  navBar.append(navButtons);
+
+  block.append(careerSlider);
+  block.append(navBar);
+
+  if(block.children){
+    // Remove all elements preceding the career slider div
+    while (careerSlider.previousElementSibling) {
+      careerSlider.parentNode.removeChild(careerSlider.previousElementSibling);
+    }
+  }
+
+  document.onkeydown = (e) => {
+    switch (e.keyCode) {
+      case 37:
+        la.onclick();
+        break;
+      case 39:
+        ra.onclick();
+        break;
+      default:
+        // do nothing
+    }
+  };
+}

--- a/blocks/card-carousel/card-carousel.js
+++ b/blocks/card-carousel/card-carousel.js
@@ -9,7 +9,7 @@ export function scrollToCard(idx, card, precedingCard, slides, span, doc) {
   const rect = card.getBoundingClientRect();
 
   // set the style on the active button
-  const buttons = doc.querySelectorAll('.career-slides-nav span.active-nav');
+  const buttons = doc.querySelectorAll('.card-slides-nav span.active-nav');
   buttons.forEach((b) => b.classList.remove('active-nav'));
   span.classList.add('active-nav');
 
@@ -55,17 +55,17 @@ export default async function decorate(block) {
   const data = shuffleArray(filterIncompleteEntries(json));
 
   const careerSlider = document.createElement('div');
-  careerSlider.classList.add('career-slider');
+  careerSlider.classList.add('card-slider');
 
   const careerSlides = document.createElement('div');
-  careerSlides.classList.add('career-slides');
+  careerSlides.classList.add('card-slides');
 
   const slideDivs = [];
   if (block.children && block.children.length > 0) {
     MAX_BUTTONS = block.children.length - 2;
     [...block.children].forEach((row) => {
       const div = document.createElement('div');
-      div.classList.add('career-card');
+      div.classList.add('carousel-childcard');
 
       const a = document.createElement('a');
       a.href = '#'; // Todo populate the Link of the stories
@@ -78,7 +78,7 @@ export default async function decorate(block) {
   } else {
     for (let i = 0; i < data.length; i += 1) {
       const div = document.createElement('div');
-      div.classList.add('career-card');
+      div.classList.add('carousel-childcard');
       const a = document.createElement('a');
       a.href = data[i].path;
       const pic = createOptimizedPicture(data[i].image, data[i].pagename);
@@ -116,9 +116,9 @@ export default async function decorate(block) {
   careerSlider.append(careerSlides);
 
   const navBar = document.createElement('div');
-  navBar.classList.add('career-slides-navbar');
+  navBar.classList.add('card-slides-navbar');
   const navButtons = document.createElement('div');
-  navButtons.classList.add('career-slides-nav');
+  navButtons.classList.add('card-slides-nav');
 
   const buttons = [];
   for (let i = 0; i < data.length && i < MAX_BUTTONS; i += 1) {

--- a/blocks/card-carousel/card-carousel.js
+++ b/blocks/card-carousel/card-carousel.js
@@ -68,8 +68,7 @@ export default async function decorate(block) {
       div.classList.add('career-card');
 
       const a = document.createElement('a');
-      //Todo populate the Link of the stories
-      a.href = '#'; 
+      a.href = '#'; // Todo populate the Link of the stories
       div.append(a);
       a.innerHTML = row.innerHTML;
 

--- a/blocks/card-carousel/card-carousel.js
+++ b/blocks/card-carousel/card-carousel.js
@@ -61,7 +61,7 @@ export default async function decorate(block) {
   careerSlides.classList.add('career-slides');
 
   const slideDivs = [];
-  if(block.children && block.children.length > 0){
+  if (block.children && block.children.length > 0) {
 
     MAX_BUTTONS = block.children.length - 2;
     [...block.children].forEach((row) => {
@@ -69,51 +69,50 @@ export default async function decorate(block) {
       div.classList.add('career-card');
 
       const a = document.createElement('a');
-      a.href = "www.google.com";
+      a.href = hrefVal || '#';
       div.append(a);
       a.innerHTML = row.innerHTML;
 
       careerSlides.append(div);
       slideDivs.push(div);
-  });
-  }
-  else{
-  for (let i = 0; i < data.length; i += 1) {
-    const div = document.createElement('div');
-    div.classList.add('career-card');
-    const a = document.createElement('a');
-    a.href = data[i].path;
-    const pic = createOptimizedPicture(data[i].image, data[i].pagename);
-    a.append(pic);
+    });
+  } else {
+    for (let i = 0; i < data.length; i += 1) {
+      const div = document.createElement('div');
+      div.classList.add('career-card');
+      const a = document.createElement('a');
+      a.href = data[i].path;
+      const pic = createOptimizedPicture(data[i].image, data[i].pagename);
+      a.append(pic);
 
-    const bqc = document.createElement('div');
-    bqc.classList.add('career-card-bqc');
-    const bq = document.createElement('blockquote');
-    bq.textContent = data[i]['career-quote'];
-    bqc.append(bq);
-    a.append(bqc);
+      const bqc = document.createElement('div');
+      bqc.classList.add('career-card-bqc');
+      const bq = document.createElement('blockquote');
+      bq.textContent = data[i]['career-quote'];
+      bqc.append(bq);
+      a.append(bqc);
 
-    const nm = document.createElement('h6');
-    nm.textContent = data[i].pagename;
-    a.append(nm);
+      const nm = document.createElement('h6');
+      nm.textContent = data[i].pagename;
+      a.append(nm);
 
-    const role = document.createElement('p');
-    role.textContent = data[i]['career-jobtitle'];
-    a.append(role);
+      const role = document.createElement('p');
+      role.textContent = data[i]['career-jobtitle'];
+      a.append(role);
 
-    const link = document.createElement('button');
-    link.textContent = placeholders['career-carousel-readmore'];
-    const arrow = document.createElement('img');
-    arrow.src = '/icons/angle-right-blue.svg';
-    arrow.alt = 'Go to testimonial';
-    arrow.classList.add('icon-angle-right-blue');
-    link.append(arrow);
-    a.append(link);
-    div.append(a);
+      const link = document.createElement('button');
+      link.textContent = placeholders['career-carousel-readmore'];
+      const arrow = document.createElement('img');
+      arrow.src = '/icons/angle-right-blue.svg';
+      arrow.alt = 'Go to testimonial';
+      arrow.classList.add('icon-angle-right-blue');
+      link.append(arrow);
+      a.append(link);
+      div.append(a);
 
-    careerSlides.append(div);
-    slideDivs.push(div);
-  }
+      careerSlides.append(div);
+      slideDivs.push(div);
+    }
   }
   careerSlider.append(careerSlides);
 
@@ -152,7 +151,7 @@ export default async function decorate(block) {
   block.append(careerSlider);
   block.append(navBar);
 
-  if(block.children){
+  if (block.children) {
     // Remove all elements preceding the career slider div
     while (careerSlider.previousElementSibling) {
       careerSlider.parentNode.removeChild(careerSlider.previousElementSibling);


### PR DESCRIPTION
To show a card-carousel (career) variant I have added it to the below URL along with the card-carousel. 
https://carouselritsriva--sunstar--hlxsites.hlx.page/_drafts/ritsriva/research1

Fixes #231

Test URLs:
- Original: https://www.sunstar.com/research
- Before: https://main--sunstar--hlxsites.hlx.live/_drafts/ritsriva/research1
- After: https://carouselritsriva--sunstar--hlxsites.hlx.page/_drafts/ritsriva/research1

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
