### PR TITLE
Added default margin to link block and variant no-margin

### DIFF
--- a/blocks/link/link.css
+++ b/blocks/link/link.css
@@ -1,3 +1,7 @@
+.block.link a {
+  margin-bottom: 1.25rem;
+}
+
 .block.link a.button {
   font-size: 1rem;
   font-weight: var(--font-weight-medium);
@@ -9,6 +13,10 @@
   position: relative;
   left: 0.3rem;
   top: 0.5rem;
+}
+
+.block.link.no-margin a {
+  margin-bottom: 0;
 }
 
 .block.link.white-button a {
@@ -61,6 +69,14 @@
 }
 
 @media (min-width: 62rem) {
+  .block.link a {
+    margin-bottom: 1.5rem;
+  }
+
+  .block.link.no-margin a {
+    margin-bottom: 0;
+  }
+
   .block.link.large-button a {
     font-size: 1.5rem;
   }
@@ -75,4 +91,6 @@
     padding: 0;
     margin: 0;
   }
+
+ 
 }

--- a/blocks/link/link.css
+++ b/blocks/link/link.css
@@ -1,4 +1,4 @@
-.block.link a {
+.block.link {
   margin-bottom: 1.25rem;
 }
 
@@ -15,7 +15,7 @@
   top: 0.5rem;
 }
 
-.block.link.no-margin a {
+.block.link.no-margin {
   margin-bottom: 0;
 }
 
@@ -69,11 +69,11 @@
 }
 
 @media (min-width: 62rem) {
-  .block.link a {
+  .block.link {
     margin-bottom: 1.5rem;
   }
 
-  .block.link.no-margin a {
+  .block.link.no-margin {
     margin-bottom: 0;
   }
 

--- a/blocks/link/link.css
+++ b/blocks/link/link.css
@@ -30,7 +30,6 @@
   font-size: 1.25rem;
   padding-top: 1.5em;
   padding-bottom: 1.5em;
-  margin-bottom: 1.5rem;
 }
 
 .block.link.large-button a::after {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #303 

Test URLs:
- Before: https://main--sunstar--hlxsites.hlx.live/jp/sustainability/s-management/philosophy
- After: https://303--sunstar--hlxsites.hlx.live/jp/sustainability/s-management/philosophy

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Link   | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [x] New variations introduced in this PR

link(no-margin)    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
