### PR TITLE
make link downloadable when it has downlod icon in it

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -179,6 +179,17 @@ export function buildImageWithCaptionBlocks(main, buildBlockFunction) {
   });
 }
 
+function buildDownloadableLinks(main) {
+  // Find all 'a' elements that have a 'span' with class 'icon-download' as a child
+  // all links which has download icon in it
+  const downloadableLinks = main.querySelectorAll('a span.icon-download');
+  // add download attribute to all links and remove target attribute if it exists
+  downloadableLinks.forEach((link) => {
+    link.parentElement.setAttribute('download', '');
+    link.parentElement.removeAttribute('target');
+  });
+}
+
 /**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
@@ -188,6 +199,7 @@ function buildAutoBlocks(main) {
     buildHeroBlock(main);
     buildModalFragmentBlock(main);
     buildImageWithCaptionBlocks(main, buildBlock);
+    buildDownloadableLinks(main);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -179,17 +179,6 @@ export function buildImageWithCaptionBlocks(main, buildBlockFunction) {
   });
 }
 
-function buildDownloadableLinks(main) {
-  // Find all 'a' elements that have a 'span' with class 'icon-download' as a child
-  // all links which has download icon in it
-  const downloadableLinks = main.querySelectorAll('a span.icon-download');
-  // add download attribute to all links and remove target attribute if it exists
-  downloadableLinks.forEach((link) => {
-    link.parentElement.setAttribute('download', '');
-    link.parentElement.removeAttribute('target');
-  });
-}
-
 /**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
@@ -199,7 +188,6 @@ function buildAutoBlocks(main) {
     buildHeroBlock(main);
     buildModalFragmentBlock(main);
     buildImageWithCaptionBlocks(main, buildBlock);
-    buildDownloadableLinks(main);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);
@@ -237,6 +225,20 @@ export function decorateExternalAnchors(externalAnchors) {
 }
 
 /**
+ * decorates links with download icon as downloadables
+ * @param {Element}s to decorate downloadableLink
+ * @returns {void}
+ */
+export function decorateDownloadableLinks(downloadableLinks) {
+  if (downloadableLinks.length) {
+    downloadableLinks.forEach((link) => {
+      link.setAttribute('download', '');
+      link.removeAttribute('target');
+    });
+  }
+}
+
+/**
  * Gets the extension of a URL.
  * @param {string} url The URL
  * @returns {string} The extension
@@ -269,6 +271,9 @@ export function decorateAnchors(element = document) {
   decorateExternalAnchors(Array.from(anchors).filter(
     (a) => a.href && (!a.href.match(`^http[s]*://${window.location.host}/`)
     || ['pdf'].includes(getUrlExtension(a.href).toLowerCase())),
+  ));
+  decorateDownloadableLinks(Array.from(anchors).filter(
+    (a) => a.querySelector('span.icon-download'),
   ));
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #320 

Test URLs:
- Original: [https://www.sunstar.com/<path>](https://www.sunstar.com/newsroom/download/)
- Before: [https://main--sunstar--hlxsites.hlx.live/<path>](https://main--sunstar--hlxsites.hlx.page/_drafts/sagar/download)
- After: [https://$branch--sunstar--hlxsites.hlx.live/<path>](https://320-autoblocking-of-downloadable-images--sunstar--hlxsites.hlx.live/_drafts/sagar/download)

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
