### PR TITLE
Enhancements to columns block: split ratios and cell alignment

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -131,6 +131,7 @@
 
 .columns.history h2 {
   border-bottom: 1px solid var(--primary);
+  margin-inline: 0;
   margin-bottom: 1rem;
   font-size: var(--heading-font-size-xl);
   font-weight: var(--font-weight-small);

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -1,3 +1,80 @@
+export function applySplitPercentages(block) {
+  const ratios = [];
+  for (let i = 0; i < block.classList.length; i += 1) {
+    const cls = block.classList[i];
+    if (cls.startsWith('split-')) {
+      const varName = `--${cls}`;
+      const numbers = getComputedStyle(block).getPropertyValue(varName);
+      numbers.split(':').forEach((n) => ratios.push(n));
+      break;
+    }
+  }
+
+  if (ratios.length === 0) {
+    return;
+  }
+
+  let pctIdx = 0;
+
+  for (let i = 0; i < block.children.length; i += 1) {
+    if (block.children[i].localName === 'div') {
+      for (let j = 0; j < block.children[i].children.length; j += 1) {
+        if (block.children[i].children[j].localName === 'div') {
+          block.children[i].children[j].style.flexBasis = ratios[pctIdx];
+          pctIdx += 1;
+
+          if (pctIdx >= ratios.length) {
+            pctIdx = 0;
+          }
+        }
+      }
+    }
+  }
+}
+
+function applyHorizontalCellAlignment(block) {
+  block.querySelectorAll(':scope div[data-align]').forEach((d) => {
+    if (d.classList.contains('text-col')) {
+      // This is a text column
+      if (d.dataset.align) {
+        d.style.textAlign = d.dataset.align;
+      }
+    } else {
+      // This is an image column
+      d.style.display = 'flex';
+      d.style.flexDirection = 'column';
+      d.style.alignItems = 'stretch';
+      d.style.justifyContent = d.dataset.align;
+    }
+  });
+}
+
+// Vertical Cell Alignment is only applied to non-text columns
+function applyVerticalCellAlignment(block) {
+  block.querySelectorAll(':scope > div > div:not(.text-col-wrapper').forEach((d) => {
+    // this is an image column
+    d.style.display = 'flex';
+    d.style.flexDirection = 'column';
+    d.style.alignItems = 'stretch';
+
+    switch (d.dataset.valign) {
+      case 'middle':
+        d.style.alignSelf = 'center';
+        break;
+      case 'bottom':
+        d.style.alignSelf = 'flex-end';
+        break;
+      default:
+        d.style.alignSelf = 'flex-start';
+    }
+  });
+}
+
+export function applyCellAlignment(block) {
+  applyHorizontalCellAlignment(block);
+  applyVerticalCellAlignment(block);
+}
+
 export default function decorate(block) {
   const background = block.classList.contains('backgroundimage');
   if (background) {
@@ -143,4 +220,7 @@ export default function decorate(block) {
       }
     });
   }
+
+  applySplitPercentages(block);
+  applyCellAlignment(block);
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -126,6 +126,9 @@
   /* Font Sizes */
   --font-size-small: 14px;
   --font-size-xsmall: 12px;
+
+  /* Column Split Ratios */
+  --split-lastquarter: 75%:25%;
 }
 
 html {

--- a/test/blocks/columns/columns.plain.html
+++ b/test/blocks/columns/columns.plain.html
@@ -1,0 +1,60 @@
+<head>
+    <style>
+        :root {
+          --split-testratio1: 80%:20%;
+          --split-testratio2: 30%:70%;
+         }
+    </style>
+</head>
+<body>
+  <div>
+    <div class="columns split-testratio1 native-image-sizes">
+      <div>
+        <div id="column-a" data-valign="middle">
+        </div>
+        <div id="column-b" data-valign="bottom">
+        </div>
+      </div>
+      <div>
+        <div id="column-x" data-align="center">
+        </div>
+        <div id="column-y" data-align="right">
+        </div>
+      </div>
+    </div>
+
+    <div class="columns split-testratio2 native-image-sizes">
+      <div>
+        <div class="text-col-wrapper">
+          <div id="column-t1" class="text-col" data-valign="middle">
+          </div>
+        </div>
+        <div class="text-col-wrapper">
+          <div id="column-t2" class="text-col" data-valign="bottom">
+          </div>
+        </div>
+      </div>
+      <div>
+        <div class="text-col-wrapper">
+          <div id="column-t3" class="text-col" data-align="center">
+          </div>
+        </div>
+        <div class="text-col-wrapper">
+          <div id="column-t4" class="text-col" data-align="right">
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="columns other native-image-sizes">
+      <div>
+        <div id="column-c">
+        </div>
+        <div id="column-d" class="text-col-wrapper">
+          <div id="column-d2" class="text-col">
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/test/blocks/columns/columns.test.js
+++ b/test/blocks/columns/columns.test.js
@@ -1,0 +1,107 @@
+/* eslint-disable no-unused-expressions */
+/* global describe before it */
+
+import { expect } from '@esm-bundle/chai';
+import { readFile } from '@web/test-runner-commands';
+
+const scripts = {};
+
+document.write(await readFile({ path: './columns.plain.html' }));
+
+describe('Columns Block', () => {
+  before(async () => {
+    const mod = await import('../../../blocks/columns/columns.js');
+    Object
+      .keys(mod)
+      .forEach((func) => {
+        scripts[func] = mod[func];
+      });
+  });
+
+  it('Handles split percentages', () => {
+    const block = document.querySelector('.columns.split-testratio1');
+
+    scripts.applySplitPercentages(block);
+
+    const ca = block.querySelector('#column-a');
+    expect(ca.style.flexBasis).to.equal('80%');
+    const cb = block.querySelector('#column-b');
+    expect(cb.style.flexBasis).to.equal('20%');
+    const cx = block.querySelector('#column-x');
+    expect(cx.style.flexBasis).to.equal('80%');
+    const cy = block.querySelector('#column-y');
+    expect(cy.style.flexBasis).to.equal('20%');
+  });
+
+  it('No split percentages if not requested', () => {
+    const block = document.querySelector('.columns.other');
+
+    scripts.applySplitPercentages(block);
+
+    const cc = block.querySelector('#column-c');
+    expect(cc.style.flexBasis).to.equal('');
+    const cd = block.querySelector('#column-d');
+    expect(cd.style.flexBasis).to.equal('');
+  });
+
+  it('Applies alignment to non-text cells', () => {
+    const block = document.querySelector('.columns.split-testratio1');
+
+    scripts.applyCellAlignment(block);
+
+    const ca = block.querySelector('#column-a');
+    expect(ca.style.display).to.equal('flex');
+    expect(ca.style.alignSelf).to.equal('center');
+
+    const cb = block.querySelector('#column-b');
+    expect(cb.style.display).to.equal('flex');
+    expect(cb.style.alignSelf).to.equal('flex-end');
+
+    const cx = block.querySelector('#column-x');
+    expect(cx.style.display).to.equal('flex');
+    expect(cx.style.justifyContent).to.equal('center');
+
+    const cy = block.querySelector('#column-y');
+    expect(cy.style.display).to.equal('flex');
+    expect(cy.style.justifyContent).to.equal('right');
+  });
+
+  it('Applies alignment to text cells', () => {
+    const block = document.querySelector('.columns.split-testratio2');
+
+    scripts.applyCellAlignment(block);
+
+    const t1 = block.querySelector('#column-t1');
+    expect(t1.style.display).to.not.equal('flex');
+    expect(t1.style.textAlign).to.equal('');
+
+    const t2 = block.querySelector('#column-t2');
+    expect(t2.style.display).to.not.equal('flex');
+    expect(t1.style.textAlign).to.equal('');
+
+    const t3 = block.querySelector('#column-t3');
+    expect(t3.style.display).to.not.equal('flex');
+    expect(t3.style.textAlign).to.equal('center');
+
+    const t4 = block.querySelector('#column-t4');
+    expect(t4.style.display).to.not.equal('flex');
+    expect(t4.style.textAlign).to.equal('right');
+  });
+
+  it('Applies default alignment', () => {
+    const block = document.querySelector('.columns.other');
+
+    scripts.applyCellAlignment(block);
+
+    const cc = block.querySelector('#column-c');
+    expect(cc.style.display).to.equal('flex');
+    expect(cc.style.alignSelf).to.equal('flex-start');
+
+    const cd = block.querySelector('#column-d');
+    expect(cd.style.display).to.not.equal('flex');
+
+    const cd2 = block.querySelector('#column-d');
+    expect(cd2.style.display).to.not.equal('flex');
+    expect(cd2.style.textAlign).to.equal('');
+  });
+});


### PR DESCRIPTION
* Specify the split ratio by adding the `split=name` attribute to the header. The actual ratio is declared as a css variable with the format --split-name, for example: `--split-products: 25%:75%`

Cell alignment as declared in the Word doc is honoured in the following way:
* text cells support horizontal alignment: left/center/right
* non-text (image) cells support horizontal alignment and vertical alignment top/middle/bottom

This is a back-merge of the changes to the columns block made in the https://github.com/hlxsites/sunstar-foundation project.

Test URLs:
- Before: https://main--sunstar--hlxsites.hlx.live/brands
- After: https://columns-split-alignment-sq--sunstar--hlxsites.hlx.live/brands


- [X] New block variations introduced in this PR

**Variation Name** :  For e.g. columns (split)
- [X] Documented in sidekick library: https://main--sunstar--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/columns&index=20

Additionally an example for cell alignment was added to the sidekick library.