### PR TITLE
issue-292 Autoblocking of breadcrumb block if its not present

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -181,11 +181,30 @@ export function buildImageWithCaptionBlocks(main, buildBlockFunction) {
 }
 
 /**
+ * Adding breadcrumb block if its not present in doc
+ * @param {*} main
+ */
+export function buildBreadcrumbBlock(main) {
+  const noBreadcrumb = getMetadata('nobreadcrumb');
+  const alreadyBreadcrumb = main.querySelector('.breadcrumb');
+
+  if ((!noBreadcrumb || noBreadcrumb === 'false') && !alreadyBreadcrumb) {
+    const section = document.createElement('div');
+    const blockEl = buildBlock('breadcrumb', { elems: [] });
+    section.append(blockEl);
+    main.prepend(section);
+  }
+}
+
+// doc.querySelector('.breadcrumb')
+
+/**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
  */
 function buildAutoBlocks(main) {
   try {
+    buildBreadcrumbBlock(main);
     buildHeroBlock(main);
     buildModalFragmentBlock(main);
     buildImageWithCaptionBlocks(main, buildBlock);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -196,8 +196,6 @@ export function buildBreadcrumbBlock(main) {
   }
 }
 
-// doc.querySelector('.breadcrumb')
-
 /**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -186,9 +186,9 @@ export function buildImageWithCaptionBlocks(main, buildBlockFunction) {
  */
 export function buildBreadcrumbBlock(main) {
   const noBreadcrumb = getMetadata('nobreadcrumb');
-  const alreadyBreadcrumb = main.querySelector('.breadcrumb');
+  const alreadyBreadcrumb = document.querySelector('.breadcrumb');
 
-  if ((!noBreadcrumb || noBreadcrumb === 'false') && !alreadyBreadcrumb) {
+  if ((!noBreadcrumb || noBreadcrumb === 'false') && !alreadyBreadcrumb && !isInternalPage()) {
     const section = document.createElement('div');
     const blockEl = buildBlock('breadcrumb', { elems: [] });
     section.append(blockEl);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #292 

Test URLs:
- Original: https://www.sunstar.com/healthy-thinking/4944/
- Before: https://main--sunstar--hlxsites.hlx.live/_drafts/piyush/4944
- After: https://auto-breadcrumb--sunstar--hlxsites.hlx.live/_drafts/piyush/4944

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. cards
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. cards (grid)
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. compact, white
- [ ] Documented in sidekick library
