### PR TITLE
Made default overlapping content have buttons, added no-buttons variant

### DIFF
--- a/blocks/overlapping-content/overlapping-content.css
+++ b/blocks/overlapping-content/overlapping-content.css
@@ -21,9 +21,11 @@
   min-width: unset;
 }
 
-.overlapping-content a.button.tertiary {
+.overlapping-content a.button.tertiary,
+.overlapping-content a.tertiary {
   background-color: unset;
   padding: 0;
+  color: var(--white);
 }
 
 .overlapping-content > div.crop > {

--- a/blocks/overlapping-content/overlapping-content.js
+++ b/blocks/overlapping-content/overlapping-content.js
@@ -1,6 +1,6 @@
 import { decorateRenderHints } from '../../scripts/lib-franklin.js';
 
-function decorateAnchors(row) {
+function decorateAnchors(row, shouldHaveButtons) {
   const anchors = row.querySelectorAll('a');
   if (anchors.length) {
     [...anchors].forEach((a) => {
@@ -9,8 +9,10 @@ function decorateAnchors(row) {
       if (up.tagName === 'P') {
         up.classList.add('button-container');
       }
-      a.classList.add('tertiary');
-      a.classList.remove('primary');
+      if (!shouldHaveButtons) {
+        a.classList.add('tertiary');
+        a.classList.remove('primary');
+      }
     });
   }
 }
@@ -57,13 +59,14 @@ function injectBackgroundDivForText(row) {
 }
 
 export default function decorate(block) {
+  const shouldHaveButtons = !block.classList.contains('no-buttons');
   decorateRenderHints(block);
 
   [...block.children].forEach((row) => {
     row.classList.add('overlapping-content-item');
     injectItemWidthVar(row);
     decorateImgContainer(row);
-    decorateAnchors(row);
+    decorateAnchors(row, shouldHaveButtons);
     injectBackgroundDivForText(row);
   });
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #339 

Test URLs:
- Original: https://www.sunstar.com/research
- Before: https://main--sunstar--hlxsites.hlx.live/research
- After: https://i-339--sunstar--hlxsites.hlx.live/research

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. cards
- [ ] Documented in sidekick library


- [x] New variations introduced in this PR
**Variation Name** :  overlapping-content (no-buttons)
- [x] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. compact, white
- [ ] Documented in sidekick library
