### PR TITLE
Column enhancements - flex-start, heading-divider, medium-margin

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -53,6 +53,13 @@
   margin: 0 auto 1rem;
 }
 
+.columns.heading-divider h2,
+.columns.heading-divider h3,
+.columns.heading-divider h4 {
+  border-bottom: 1px solid var(--light-black);
+  padding-bottom: 1rem;
+}
+
 .columns :not(.table) h4 {
   font-size: var(--heading-font-size-mxs);
 }
@@ -162,11 +169,8 @@
   max-width: 1200px;
 }
 
-.columns.heading-divider h2,
-.columns.heading-divider h3,
-.columns.heading-divider h4 {
-  border-bottom: 1px solid var(--light-black);
-  padding-bottom: 1rem;
+.columns.medium-margin > div {
+  margin-bottom: 4rem;
 }
 
 .columns.plain-links > div > div,
@@ -182,6 +186,10 @@
 
 .columns.text-layout > div > div > div {
   font-size: var(--body-font-size-l);
+}
+
+.columns.flex-start.medium-margin > div {
+  margin-bottom: 4rem;
 }
 
 .columns.history.invert-image-order-in-narrow-view > div,
@@ -324,7 +332,7 @@ div.img-col > video {
   width: 100%;
 }
 
-.columns > div > div:not(.columns-img-col) div:not(.img-col) {
+.columns:not(.no-padding) > div > div:not(.columns-img-col) div:not(.img-col) {
   padding: 0 1rem;
 }
 
@@ -411,8 +419,6 @@ div.img-col > video {
     gap: 3rem;
     margin-bottom: 7.5rem;
   }
-
-
 
   .columns p.button-container {
     flex-direction: row;
@@ -566,7 +572,7 @@ div.img-col > video {
     width: 337px;
   }
 
-  .columns:not(.absolute-no-padding) > div > div:not(.columns-img-col) div:not(.img-col) {
+  .columns:not(.no-padding) > div > div:not(.columns-img-col) div:not(.img-col) {
     padding: 1rem 0;
   }
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #345 

Test URLs:
- Original: https://www.sunstar.com/sustainability/environment/climate-resource-waste/
- Before: https://main--sunstar--hlxsites.hlx.live/sustainability/environment/climate-resource-waste
- After: https://345-column-block-enhancement--sunstar--hlxsites.hlx.live/sustainability/environment/climate-resource-waste

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. cards
- [ ] Documented in sidekick library


- [X] New variations introduced in this PR
**Variation Name** :  Column (heading-divider) , Column (Medium Margin)
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. compact, white
- [ ] Documented in sidekick library
