### PR TITLE
Adding Download icon support in text block and light background variant

### DIFF
--- a/blocks/text/text.css
+++ b/blocks/text/text.css
@@ -123,7 +123,7 @@ main .block.text.light-background  > div > div > :last-child {
 
   main .block.text.light-background {
     margin-block: 1.5rem;
-    padding: 3rem;
+    padding: 2rem;
   }
 
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #363 

## Changelog:
_Please enter each change as a new bullet point_

## Test URLs:
- Original: https://www.sunstar.com/jp/newsroom/news/20210330/
- Before: https://main--sunstar--hlxsites.hlx.live/jp/newsroom/20231002
- After: https://363--sunstar--hlxsites.hlx.live/jp/newsroom/20231002

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [X] New variations introduced in this PR
 :  Text(light-background, download)
- [X] Documented in sidekick library
https://main--sunstar--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/text&index=5
https://main--sunstar--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/text&index=6

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
