### PR TITLE
Add a variation to link block to support large background button

### DIFF
--- a/blocks/link/link.css
+++ b/blocks/link/link.css
@@ -36,6 +36,57 @@
   content: unset;
 }
 
+.block.link.large-background-button {
+  background-color: var(--primary);
+  max-width: 100%;
+  margin: 0 1rem;
+  margin-bottom: 2.5rem;
+  position: relative;
+}
+
+.block.link.large-background-button:hover {
+  background: var(--link-color);
+}
+
+.block.link.large-background-button a {
+  padding: 1.5rem;
+}
+
+.block.link.large-background-button a:hover {
+  text-decoration: none;
+}
+
+.block.link.large-background-button .download-icon {
+  position: absolute;
+  top: 1.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
+}  
+
+.block.link.large-background-button .download-details {
+  position: relative;
+  margin-left: 1.375rem;
+}  
+
+.block.link.large-background-button .download-details h6 {
+  color: var(--hero-strong-color);
+  font-size: var(--body-font-size-s);
+  line-height: 1.3rem;
+  margin: 0 1rem 0 3.625rem;
+  text-transform: unset;
+  letter-spacing: 0.05em;
+}  
+
+.block.link.large-background-button .download-details h2 {
+  font-size: var(--body-font-size-xxl);
+  line-height: 1.75rem;
+  margin-top: 0.75rem;
+  margin-bottom: unset;
+  display: inline-block;
+  color: var(--white);
+  text-align: left;
+}  
+
 .block.link.white-button a:hover {
   color: var(--white);
   background-color: var(--link-blue-color);
@@ -91,5 +142,43 @@
     margin: 0;
   }
 
+  .block.link.large-background-button {
+    margin: 0 0 2.5rem;
+  }
  
+  .block.link.large-background-button a {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 2.5rem 6rem;
+  }
+
+  .block.link.large-background-button .download-icon {
+    position: unset;
+    width: 3.5rem;
+    height: 3.5rem;
+  }  
+
+  .block.link.large-background-button .download-details {
+    position: relative;
+    margin-left: 1.375rem;
+    width: 39.375rem;
+  }  
+
+  .block.link.large-background-button .download-details h6 {
+    margin: unset;
+  }  
+  
+  .block.link.large-background-button .download-details h2 {
+    font-size: var(--heading-font-size-mxl);
+    line-height: 3rem;
+    margin: unset;
+    display: unset;
+  }  
 }
+
+@media (min-width: 77rem) {
+  .block.link.large-background-button a {
+    padding: 2.5rem 14.5rem;
+  }
+}  

--- a/blocks/link/link.js
+++ b/blocks/link/link.js
@@ -5,4 +5,32 @@ export default async function decorate(block) {
       a.setAttribute('download', '');
     }
   }
+
+  if (block.classList.contains('large-background-button')) {
+    if (block.children[0] && block.children[0].children[0]) {
+      const a = document.createElement('a');
+      a.classList.add('download-link');
+      const icon = document.createElement('img');
+      icon.src = '/icons/download-orange.svg';
+      icon.classList.add('download-icon');
+      let href = '';
+      const contents = block.children[0].children[0];
+      [...contents.children].forEach((item) => {
+        const link = block.querySelector('a');
+        if (link) {
+          item.textContent = link.textContent;
+          if (link.href && !href) {
+            href = link.href;
+          }
+          link.remove();
+        }
+      });
+      contents.classList.add('download-details');
+      a.href = href;
+      a.target = '_blank';
+      a.appendChild(icon);
+      a.appendChild(contents);
+      block.replaceChildren(a);
+    }
+  }
 }

--- a/icons/download-orange.svg
+++ b/icons/download-orange.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 56 56"><path fill="#F68D2E" fill-rule="evenodd" d="M25.667 38.7V4.666h4.666V38.7l12.35-12.35 3.3 3.3L28 47.633 10.017 29.65l3.3-3.3 12.35 12.35ZM0 39.666h4.667v11.667h46.666V39.667H56V56H0V39.666Z" clip-rule="evenodd"/></svg>


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #382 

## Changelog:

- Add a new variation
- Didn't change any existed logic

## Test URLs:
- Original: https://www.sunstar.com/healthy-thinking-report/oral-survey-2021
- Before: https://main--sunstar--hlxsites.hlx.live/healthy-thinking-report/oral-survey-2021
- After: https://link-large-button--sunstar--hlxsites.hlx.page/healthy-thinking-report/oral-survey-2021

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [x] New variations introduced in this PR
**Variation Name** :  Link(large-background-button)
- [x] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
