### PR TITLE
Breadcrumb fix for large text

### DIFF
--- a/blocks/breadcrumb/breadcrumb.css
+++ b/blocks/breadcrumb/breadcrumb.css
@@ -4,7 +4,7 @@
   font-weight: var(--font-weight-medium);
   line-height: 1;
   display: none;
-  height: 2.08rem;
+  min-height: 2.08rem;
 }
 
 .section.breadcrumb-container.visible {
@@ -29,6 +29,7 @@
   margin: 0;
   list-style: none;
   display: flex;
+  flex-wrap: wrap;
 }
 
 .breadcrumb-item {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes

## Changelog:
Breadcrumb is distorted for screens -> tablet and mobile

## Test URLs:
- Original: https://www.sunstar.com/jp/newsroom/news/20231002/
- Before: https://main--sunstar--hlxsites.hlx.live/jp/newsroom/20231002
- After: https://breadcrumb-fix--sunstar--hlxsites.hlx.live/jp/newsroom/20231002

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
