### PR TITLE
Add a variation to Column block to support 3 columns of title text link contents

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -173,6 +173,34 @@
   margin-bottom: 4rem;
 }
 
+.columns.title-text-link {
+  padding: 3.5rem 0;
+  margin: unset;
+}
+
+.columns.title-text-link h4 {
+  font-size: var(--heading-font-size-s);
+  margin-bottom: 0.5rem;
+}
+
+.columns.title-text-link p {
+  font-size: var(--body-font-size-s);
+}
+
+.columns.title-text-link a {
+  background: unset;
+  color: var(--link-color);
+  height: unset;
+  line-height: 1.5;
+  display: block;
+  padding: unset;
+}
+
+.columns.title-text-link > div {
+  gap: 2.5rem;
+  margin-bottom: unset;
+}
+
 .columns.plain-links > div > div,
 .columns.plain-links > div > div p {
   font-size: var(--body-font-size-s);
@@ -465,6 +493,19 @@ div.img-col > video {
     display: table;
     width: 100%;
   }
+
+  .columns.title-text-link {
+    padding: 4.875rem 0;
+  }
+
+  .columns.title-text-link > div {
+    gap: unset;
+  }
+
+  .columns.title-text-link h4 {
+    font-size: var(--heading-font-size-s);
+    margin-bottom: 0.5rem;
+}
 
   .columns > div .img-col {
     order: unset;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #401 

## Changelog:
- Add a variation to column block to support 3 columns of title & text & link contents
- Didn't change any other existing logic

## Test URLs:
- Original: https://www.sunstar.com/healthy-thinking-report/oral-survey-2021
- Before: https://main--sunstar--hlxsites.hlx.live/healthy-thinking-report/oral-survey-2021
- After: https://column-title-text-link--sunstar--hlxsites.hlx.live/healthy-thinking-report/oral-survey-2021

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [x] New variations introduced in this PR
**Variation Name** :  Columns(title-text-link) 
- [x] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
