### PR TITLE
Add a variation to Social block to support horizontal social icons for all views

### DIFF
--- a/blocks/social/social.css
+++ b/blocks/social/social.css
@@ -162,6 +162,10 @@ main .section.social-container a.category-title {
   font-weight:  var(--font-weight-bold);
 }
 
+.block.social.horizontal-icon {
+  justify-content: center;
+}
+
 @media (min-width: 62rem) {
   main .section.social-container .section-container {
     position: relative;
@@ -217,6 +221,16 @@ main .section.social-container a.category-title {
 
   div.social-container h3 {
     font-size: var(--heading-font-size-m);
+  }
+
+  .block.social.horizontal-icon {
+    flex-direction: row;
+    gap: 1rem;
+    position: unset;
+  }
+
+  .block.social.horizontal-icon > span {
+    display: none;
   }
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #398

## Changelog:

- Add a variation to social block to support horizontal social icons for all views
- Didn't change any other existing logic

## Test URLs:
- Original: https://www.sunstar.com/healthy-thinking-report/oral-survey-2021
- Before: https://main--sunstar--hlxsites.hlx.live/healthy-thinking-report/oral-survey-2021
- After: https://social-horizontal-icons--sunstar--hlxsites.hlx.live/healthy-thinking-report/oral-survey-2021

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [x] New variations introduced in this PR
**Variation Name** :  Social(horizontal-icon) 
- [x] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
