### PR TITLE
Small styling changes for healthy thinking report page

### DIFF
--- a/blocks/hero-banner/hero-banner.css
+++ b/blocks/hero-banner/hero-banner.css
@@ -69,6 +69,10 @@
     position: relative;
 }
 
+.hero-banner.image-fit img {
+    height: 15rem;
+}
+
 .hero-banner.careers .hero-banner-text-container {
     background: unset;
     flex-direction: column;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -318,7 +318,7 @@ export function getWindowSize() {
 export function addTopSpacingStyleToFirstMatchingSection(main) {
   const excludedClasses = ['static', 'spacer-container', 'feed-container', 'modal-fragment-container',
     'hero-banner-container', 'hero-career-container', 'breadcrumb-container', 'hero-horizontal-tabs-container',
-    'carousel-container', 'with-background-image'];
+    'carousel-container', 'with-background-image', 'report-overview-container'];
   const sections = [...main.querySelectorAll(':scope > div')];
   let added = false;
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -592,16 +592,6 @@ main .section.auto-top-spacing .section-container {
   padding-top: 0 !important;
 }
 
-/* section - left align headings */
-main .left-align-headings h1,
-main .left-align-headings h2,
-main .left-align-headings h3,
-main .left-align-headings h4,
-main .left-align-headings h5,
-main .left-align-headings h6 {
-  text-align: left;
-}
-
 /* section - bold headings */
 
 main .section.bold-headings h1,
@@ -765,6 +755,16 @@ main .section.static > .section-container,
 main .section.static > .tab-item.active > .section-container {
   padding: 0 1rem 2rem;
   margin-bottom: 5rem;
+}
+
+/* section - text align left */
+main .section.left-align-text h1,
+main .section.left-align-text h2,
+main .section.left-align-text h3,
+main .section.left-align-text h4,
+main .section.left-align-text h5,
+main .section.left-align-text h6 {
+  text-align: left;
 }
 
 main .section.static .section-container h1 {
@@ -949,16 +949,6 @@ main .block.download a::after {
     display: block;
   }
 
-  /* section - left align headings */
-  main .left-align-headings h1,
-  main .left-align-headings h2,
-  main .left-align-headings h3,
-  main .left-align-headings h4,
-  main .left-align-headings h5,
-  main .left-align-headings h6 {
-    text-align: center;
-  }
-
   /* START Section Styles START */
 
   main .section .section-container {
@@ -1014,6 +1004,16 @@ main .block.download a::after {
     margin-left: auto;
     max-width: 45rem;
     margin-block-end: 3rem;
+  }
+
+  /* section - text align left */
+  main .section.left-align-text h1,
+  main .section.left-align-text h2,
+  main .section.left-align-text h3,
+  main .section.left-align-text h4,
+  main .section.left-align-text h5,
+  main .section.left-align-text h6 {
+    text-align: center;
   }
 
   /* section - margin-bottom */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -592,6 +592,16 @@ main .section.auto-top-spacing .section-container {
   padding-top: 0 !important;
 }
 
+/* section - left align headings */
+main .left-align-headings h1,
+main .left-align-headings h2,
+main .left-align-headings h3,
+main .left-align-headings h4,
+main .left-align-headings h5,
+main .left-align-headings h6 {
+  text-align: left;
+}
+
 /* section - bold headings */
 
 main .section.bold-headings h1,
@@ -755,16 +765,6 @@ main .section.static > .section-container,
 main .section.static > .tab-item.active > .section-container {
   padding: 0 1rem 2rem;
   margin-bottom: 5rem;
-}
-
-/* section - text align left */
-main .section.left-align-text h1,
-main .section.left-align-text h2,
-main .section.left-align-text h3,
-main .section.left-align-text h4,
-main .section.left-align-text h5,
-main .section.left-align-text h6 {
-  text-align: left;
 }
 
 main .section.static .section-container h1 {
@@ -949,6 +949,16 @@ main .block.download a::after {
     display: block;
   }
 
+  /* section - left align headings */
+  main .left-align-headings h1,
+  main .left-align-headings h2,
+  main .left-align-headings h3,
+  main .left-align-headings h4,
+  main .left-align-headings h5,
+  main .left-align-headings h6 {
+    text-align: center;
+  }
+
   /* START Section Styles START */
 
   main .section .section-container {
@@ -1004,16 +1014,6 @@ main .block.download a::after {
     margin-left: auto;
     max-width: 45rem;
     margin-block-end: 3rem;
-  }
-
-  /* section - text align left */
-  main .section.left-align-text h1,
-  main .section.left-align-text h2,
-  main .section.left-align-text h3,
-  main .section.left-align-text h4,
-  main .section.left-align-text h5,
-  main .section.left-align-text h6 {
-    text-align: center;
   }
 
   /* section - margin-bottom */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -757,6 +757,16 @@ main .section.static > .tab-item.active > .section-container {
   margin-bottom: 5rem;
 }
 
+/* section - text align left */
+main .section.left-align-text h1,
+main .section.left-align-text h2,
+main .section.left-align-text h3,
+main .section.left-align-text h4,
+main .section.left-align-text h5,
+main .section.left-align-text h6 {
+  text-align: left;
+}
+
 main .section.static .section-container h1 {
   font-size: var(--heading-font-size-l);
   margin: 3rem 0 2rem;
@@ -994,6 +1004,16 @@ main .block.download a::after {
     margin-left: auto;
     max-width: 45rem;
     margin-block-end: 3rem;
+  }
+
+  /* section - text align left */
+  main .section.left-align-text h1,
+  main .section.left-align-text h2,
+  main .section.left-align-text h3,
+  main .section.left-align-text h4,
+  main .section.left-align-text h5,
+  main .section.left-align-text h6 {
+    text-align: center;
   }
 
   /* section - margin-bottom */


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #300 

## Changelog:

- Adjust some small styling changes for Healthy Thinking Report page
- Filter adding auto space to report-overview block
- Add a variation to hero-banner to make image looks better in mobile view

## Test URLs:
- Original: https://www.sunstar.com/healthy-thinking-report/oral-survey-2021
- Before: https://main--sunstar--hlxsites.hlx.live/healthy-thinking-report/oral-survey-2021
- After: https://htr-page-styling--sunstar--hlxsites.hlx.live/healthy-thinking-report/oral-survey-2021

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [x] New variations introduced in this PR
**Variation Name** :  hero-banner(image-fit) 
- [x] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
