### PR TITLE
Fix Native Size Images 

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -121,12 +121,6 @@
   order: 2;
 }
 
-.columns:not(.native-image-sizes) .text-col-wrapper img {
-  width: 100%;
-  height: auto;
-  vertical-align: middle;
-}
-
 .columns.crop-image img {
   object-fit: cover;
   height: 100%;
@@ -134,6 +128,12 @@
 
 .columns > div > .img-col img {
   display: block;
+}
+
+.columns:not(.native-image-sizes) .text-col-wrapper img {
+  width: 100%;
+  height: auto;
+  vertical-align: middle;
 }
 
 .columns > div > div p {

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -44,6 +44,10 @@
   width: 100%;
 }
 
+.columns.native-image-sizes img {
+  width:auto;
+}
+
 .columns h2,
 .columns h3,
 .columns h4 {
@@ -117,7 +121,7 @@
   order: 2;
 }
 
-.columns .text-col-wrapper img {
+.columns:not(.native-image-sizes) .text-col-wrapper img {
   width: 100%;
   height: auto;
   vertical-align: middle;
@@ -261,7 +265,7 @@
   margin: unset;
 }
 
-.columns.text-and-image-in-column > div div.text-col img {
+.columns:not(.native-image-sizes).text-and-image-in-column > div div.text-col img {
   height: 100%;
   width: 100%;
   object-fit: cover;

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -45,7 +45,7 @@
 }
 
 .columns.native-image-sizes img {
-  width:auto;
+  width: auto;
 }
 
 .columns h2,


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

Native Image Size variant on columns doesn't work

Fixes #378

## Changelog:
_Please enter each change as a new bullet point_

## Test URLs:
- Original: http://localhost:3000/jp/newsroom/20221003
- Before: https://main--sunstar--hlxsites.hlx.page/jp/newsroom/20221003
- After: https://fixnativeimage--sunstar--hlxsites.hlx.page/jp/newsroom/20221003

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
