### PR TITLE
Added box-sizing to prevent content overflow due to padding or border

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -784,6 +784,7 @@ main .section.narrower > .tab-item.active > .section-container {
   margin: auto;
   margin-block-end: 3rem;
   max-width: 45rem;
+  box-sizing: border-box;
 }
 
 /* section - narrow/narrower with background image compatibility */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -774,6 +774,7 @@ main .section.narrow > .tab-item.active > .section-container {
   padding: 0 1rem;
   margin: auto;
   max-width: 42rem;
+  box-sizing: border-box;
 }
 
 /* section - narrower */


### PR DESCRIPTION
Fixes #457 

## Changelog:

Trivial: Added box-sizing to prevent content overflow due to padding or border

## Test URLs:
- Original: https://www.sunstar.com/about/history
- Before: https://main--sunstar--hlxsites.hlx.live/about/history
- After: https://issue-457--sunstar--hlxsites.hlx.live/about/history

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
