### PR TITLE
setting border-box at global level

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -146,8 +146,11 @@
   --split-lastthird: 66%:34%;
 }
 
+*, *::before, *::after { box-sizing: inherit; }
+
 html {
   scroll-behavior: smooth;
+  box-sizing: border-box;
 }
 
 body {


### PR DESCRIPTION
Changelog:
Trivial: Added box-sizing to prevent content overflow due to padding or border

Test URLs:
Original: https://www.sunstar.com/about/history
Before: https://main--sunstar--hlxsites.hlx.live/about/history
After: https://issue-457--sunstar--hlxsites.hlx.live/about/history


## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
