### PR TITLE
Changed icon sizes + no auto breadcrumb for mobile

### DIFF
--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -5,6 +5,7 @@ import {
   getLanguangeSpecificPath,
   fetchTagsOrCategories,
   setMetaTag,
+  getViewPort,
 } from '../../scripts/scripts.js';
 import { fetchPlaceholders, getMetadata } from '../../scripts/lib-franklin.js';
 
@@ -51,6 +52,9 @@ function setTagPageTitle(tagPageTitle) {
 }
 
 async function createAutoBreadcrumb(block, placeholders) {
+  if (getViewPort() === 'mobile') {
+    return;
+  }
   const pageIndex = (await fetchIndex('query-index')).data;
   fixExcelFilterZeroes(pageIndex);
   const { pathname } = window.location;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -336,7 +336,7 @@ export function addTopSpacingStyleToFirstMatchingSection(main) {
   });
 }
 
-function getViewPort() {
+export function getViewPort() {
   const { width } = getWindowSize();
   if (width >= 1232) {
     return 'desktop';

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -410,8 +410,8 @@ main pre {
   background-position: center;
   background-size: cover;
   display: inline-block;
-  height: 16px;
-  width: 16px;
+  height: 20px;
+  width: 24px;
 }
 
 .icon svg {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #460 
Fixes #462 

## Changelog:

- Adjusted default icon size to fit all icons (bigger icons set their own size)
- Made it so the auto breadcrumb creation does not happen for mobile


## Test URLs:
- Original: https://www.sunstar.com/about/business-performance
- Before: https://main--sunstar--hlxsites.hlx.live/about/business-performance
- After: https://i-460--sunstar--hlxsites.hlx.live/about/business-performance

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
