### PR TITLE
Feed now correctly compares numbers

### DIFF
--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -5,6 +5,7 @@ import {
   getLanguangeSpecificPath,
   fetchTagsOrCategories,
   setMetaTag,
+  getViewPort,
 } from '../../scripts/scripts.js';
 import { fetchPlaceholders, getMetadata } from '../../scripts/lib-franklin.js';
 
@@ -51,6 +52,9 @@ function setTagPageTitle(tagPageTitle) {
 }
 
 async function createAutoBreadcrumb(block, placeholders) {
+  if (getViewPort() === 'mobile') {
+    return;
+  }
   const pageIndex = (await fetchIndex('query-index')).data;
   fixExcelFilterZeroes(pageIndex);
   const { pathname } = window.location;

--- a/blocks/feed/feed.js
+++ b/blocks/feed/feed.js
@@ -105,7 +105,7 @@ export default async function decorate(block) {
   const blockType = (blockName.split('(')[0]).trim();
   const variation = (blockName.match(/\((.+)\)/) === null ? '' : blockName.match(/\((.+)\)/)[1]).trim();
   const queryObj = await queryIndex(`${getLanguage()}-search`);
-
+  const sortCriteria = blockCfg.sort ? blockCfg.sort.trim().toLowerCase() : 'path';
   // Get the query string, which includes the leading "?" character
   const queryString = window.location.search;
 
@@ -134,8 +134,8 @@ export default async function decorate(block) {
       match = tagList.some((tag) => elTags.includes(tag.trim()));
     }
     return match;
-  })
-    .orderByDescending((el) => (blockCfg.sort ? el[blockCfg.sort.trim().toLowerCase()] : el.path))
+  }) // eslint-disable-next-line max-len
+    .orderByDescending((el) => (Number.isNaN(el[sortCriteria]) ? el[sortCriteria] : parseInt(el[sortCriteria], 10)))
     .take(blockCfg.count ? parseInt(blockCfg.count, 10) : 4)
     .toList();
   block.innerHTML = '';

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -336,7 +336,7 @@ export function addTopSpacingStyleToFirstMatchingSection(main) {
   });
 }
 
-function getViewPort() {
+export function getViewPort() {
   const { width } = getWindowSize();
   if (width >= 1232) {
     return 'desktop';

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -410,8 +410,8 @@ main pre {
   background-position: center;
   background-size: cover;
   display: inline-block;
-  height: 16px;
-  width: 16px;
+  height: 20px;
+  width: 24px;
 }
 
 .icon svg {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #456 

## Changelog:

- Made feed compare numbers not strings when dealing with dates

## Test URLs:
- Original: https://www.sunstar.com/healthy-thinking/sustainability
- Before: https://main--sunstar--hlxsites.hlx.live/healthy-thinking/sustainability
- After: https://i-456--sunstar--hlxsites.hlx.live/healthy-thinking/sustainability

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
