### PR TITLE
feed now correctly compares numbers

### DIFF
--- a/blocks/feed/feed.js
+++ b/blocks/feed/feed.js
@@ -105,6 +105,7 @@ export default async function decorate(block) {
   const blockType = (blockName.split('(')[0]).trim();
   const variation = (blockName.match(/\((.+)\)/) === null ? '' : blockName.match(/\((.+)\)/)[1]).trim();
   const queryObj = await queryIndex(`${getLanguage()}-search`);
+  const sortCriteria = blockCfg.sort ? blockCfg.sort.trim().toLowerCase() : 'path';
 
   // Get the query string, which includes the leading "?" character
   const queryString = window.location.search;
@@ -134,8 +135,8 @@ export default async function decorate(block) {
       match = tagList.some((tag) => elTags.includes(tag.trim()));
     }
     return match;
-  })
-    .orderByDescending((el) => (blockCfg.sort ? el[blockCfg.sort.trim().toLowerCase()] : el.path))
+  }) // eslint-disable-next-line max-len
+    .orderByDescending((el) => (Number.isNaN(el[sortCriteria]) ? el[sortCriteria] : parseInt(el[sortCriteria], 10)))
     .take(blockCfg.count ? parseInt(blockCfg.count, 10) : 4)
     .toList();
   block.innerHTML = '';


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #456 

## Changelog:

- Made `feed` compare numbers not strings for dates

## Test URLs:
- Original: https://www.sunstar.com/healthy-thinking/sustainability
- Before: https://main--sunstar--hlxsites.hlx.live/healthy-thinking/sustainability
- After: https://feed-num-compare--sunstar--hlxsites.hlx.live/healthy-thinking/sustainability

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
