### PR TITLE
Variant of Link Block to support Breadcrumb style

### DIFF
--- a/blocks/link/link.css
+++ b/blocks/link/link.css
@@ -111,6 +111,23 @@
   flex-grow: 1;
 }
 
+/* Breadcrumb Link */
+.block.link.breadcrumb nav {
+  display: flex;
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
+.block.link.breadcrumb nav a {
+  padding-right: 32px;
+}
+
+.block.link.breadcrumb.arrow a::after {
+  content: url("../../icons/angle-right-blue.svg");
+  margin-left: 8px;
+  vertical-align: middle;
+  background-size: contain;
+}
+
 @media (min-width: 62rem) {
   .block.link {
     margin-bottom: 1.5rem;

--- a/blocks/link/link.css
+++ b/blocks/link/link.css
@@ -126,6 +126,7 @@
   margin-left: 8px;
   vertical-align: middle;
   background-size: contain;
+  top: 0;
 }
 
 @media (min-width: 62rem) {

--- a/blocks/link/link.js
+++ b/blocks/link/link.js
@@ -25,5 +25,22 @@ export default async function decorate(block) {
       a.appendChild(contents);
       block.replaceChildren(a);
     }
+  } else if (block.classList.contains('breadcrumb')) {
+    const anchorElements = block.querySelectorAll('.button-container a');
+
+    const navElement = document.createElement('nav');
+
+    anchorElements.forEach((anchor) => {
+      const href = anchor.getAttribute('href');
+      const title = anchor.getAttribute('title');
+
+      const newAnchor = document.createElement('a');
+      newAnchor.setAttribute('href', `/${href.split('/').pop()}/`);
+      newAnchor.innerHTML = `${title}`;
+
+      navElement.appendChild(newAnchor);
+    });
+
+    block.replaceChildren(navElement);
   }
 }


### PR DESCRIPTION
Fixes #447 

## Changelog:
Added variant of Link Block to support Breadcrumb style

## Test URLs:
- Original: https://www.sunstar.com/about
- Before: https://main--sunstar--hlxsites.hlx.live/_drafts/shroti/about
- After: https://issue-447--sunstar--hlxsites.hlx.page/_drafts/shroti/about

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
