### PR TITLE
Variant of Link Block to support Breadcrumb style 

### DIFF
--- a/blocks/link/link.css
+++ b/blocks/link/link.css
@@ -111,6 +111,12 @@
   flex-grow: 1;
 }
 
+.block.link.breadcrumb.arrow a::after {
+  left: 0;
+  top: 0;
+  padding-inline: 8px;
+}
+
 @media (min-width: 62rem) {
   .block.link {
     margin-bottom: 1.5rem;

--- a/blocks/link/link.css
+++ b/blocks/link/link.css
@@ -115,6 +115,7 @@
   left: 0;
   top: 0;
   padding-inline: 8px;
+  vertical-align: middle;
 }
 
 @media (min-width: 62rem) {

--- a/icons/angle-right-blue.svg
+++ b/icons/angle-right-blue.svg
@@ -1,1 +1,1 @@
-<svg width="8" height="12" style="transform: scale(-1, 1)" xmlns="http://www.w3.org/2000/svg"><path d="M7.665 10.176l-1.326 1.326L.676 5.839 6.34.176l1.326 1.326-4.337 4.337z" fill="#007CAD" fill-rule="evenodd"/></svg>
+<svg width="8" height="12" style="transform: scale(-1, -1)" xmlns="http://www.w3.org/2000/svg"><path d="M.735 1.326l1.06-1.06 4.53 4.53-4.53 4.53-1.06-1.06 3.47-3.47z" fill="#007CAD" fill-rule="evenodd"/></svg>

--- a/icons/angle-right-blue.svg
+++ b/icons/angle-right-blue.svg
@@ -1,1 +1,1 @@
-<svg width="8" height="12" style="transform: scale(-1, -1)" xmlns="http://www.w3.org/2000/svg"><path d="M.735 1.326l1.06-1.06 4.53 4.53-4.53 4.53-1.06-1.06 3.47-3.47z" fill="#007CAD" fill-rule="evenodd"/></svg>
+<svg width="8" height="12" xmlns="http://www.w3.org/2000/svg"><path d="M.735 1.326l1.06-1.06 4.53 4.53-4.53 4.53-1.06-1.06 3.47-3.47z" fill="#007CAD" fill-rule="evenodd"/></svg>


### PR DESCRIPTION
Fixes #447 

Variant of Link Block to support Breadcrumb style 

## Test URLs:

- Original: https://www.sunstar.com/about
- Before: https://main--sunstar--hlxsites.hlx.live/_drafts/shroti/about
- After: https://issue-447-v2--sunstar--hlxsites.hlx.page/_drafts/shroti/about

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
