### PR TITLE
centred blocks in sections with bg images

### DIFF
--- a/blocks/hero-banner/hero-banner.css
+++ b/blocks/hero-banner/hero-banner.css
@@ -292,8 +292,8 @@
     .hero-banner.overlap .hero-banner-text-container {
         display: block;
         padding: 3rem 2rem;
-        width: 24.25rem;
-        height: 26rem;
+        width: 28.25rem;
+        height: 32rem;
     }
 
     .hero-banner.overlap .hero-banner-text-wrapper {
@@ -370,8 +370,8 @@
 
     .hero-banner.overlap .hero-banner-text-container {
         padding: 10rem 3.75rem 0;
-        width: 27.5rem;
-        height: 33.75rem;
+        width: 35rem;
+        height: 43.75rem;
     }
 
     .hero-banner.overlap .hero-banner-media-section {
@@ -382,7 +382,7 @@
 /* Variation small-box */
 @media (min-width: 62rem) {
     .hero-banner.overlap.small-box .hero-banner-text-container {
-        height: 23.75rem;
+        height: 29.75rem;
         margin-top: 1rem;
         display: flex;
         align-items: center;
@@ -409,7 +409,7 @@
     .hero-banner.overlap.small-box .hero-banner-text-container {
         padding: 3rem;
         margin-top: 3rem;
-        height: 23.75rem;
+        height: 29.75rem;
     }
 
     .hero-banner.overlap.small-box .hero-banner-text-wrapper h2 {

--- a/blocks/hero-horizontal-tabs/hero-horizontal-tabs.css
+++ b/blocks/hero-horizontal-tabs/hero-horizontal-tabs.css
@@ -217,8 +217,8 @@ main .hero-horizontal-tabs a.button.primary.video-link::after {
   }
 
   main .hero-horiz-tabs-img picture {
-    width: calc(50vw);
-    height: 25rem;
+    width: calc(50vw - 1rem);
+    height: 26rem;
   }
 
   main .hero-horizontal-tabs nav {

--- a/blocks/text/text.css
+++ b/blocks/text/text.css
@@ -97,8 +97,8 @@ main .block.text.rounded-border  h4 {
 
 main .block.text.lead {
   font-size: var(--body-font-size-xl);
-  margin: 0 0 1.25rem;
-  
+  margin: 1rem 1rem 1.25rem;
+  max-width: 90vw;
 }
 
 main .block.text.colored {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -964,7 +964,7 @@ main .section.float-image-right picture {
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
-.section.section.with-background-image .section-container {
+.section.with-background-image .section-container {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -964,6 +964,13 @@ main .section.float-image-right picture {
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
+.section.section.with-background-image .section-container {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
 .section.with-background-image > picture > img, .section.with-static-background-image > picture > img {
   display: block;
   object-fit: cover;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -964,13 +964,6 @@ main .section.float-image-right picture {
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
-.section.with-background-image .section-container {
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-
-/* stylelint-disable-next-line no-descending-specificity */
 .section.with-background-image > picture > img, .section.with-static-background-image > picture > img {
   display: block;
   object-fit: cover;
@@ -982,8 +975,9 @@ main .section.float-image-right picture {
 .section.with-background-image > .tab-item.active > .section-container {
   display: block;
   position: absolute;
-  top: 0;
-  left: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   width: 100%;
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #437 

## Changelog:

- Changed default behaviour of blocks in sections with bg images to get centred
- Fixed (some) heroes that have the wrong height
- Fixed text block touching the end of the page


## Test URLs:
- Original: https://www.sunstar.com/about/chairman-interview
- Before: https://main--sunstar--hlxsites.hlx.live/about/chairman-interview
- After: https://i-437--sunstar--hlxsites.hlx.live/about/chairman-interview

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
