### PR TITLE
Styles for default-content-wrapper and display-block mixin

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -341,6 +341,10 @@ main .block.lead p {
 
 
 /* Mixins carry !important to override the default styles */
+.display-block * {
+  display: block!important;
+}
+
 .no-borders * {
   border: none!important;
   box-shadow: none!important;
@@ -633,6 +637,14 @@ main .section.auto-top-spacing .section-container {
   margin-top: 3rem !important;
 }
 
+main .section .default-content-wrapper > :first-child {
+  margin-top: 0;
+}
+
+main .section .default-content-wrapper > :last-child {
+  margin-bottom: 0;
+}
+
 /* section - no-padding-top for h1 */
 .header-no-top-padding h1 {
   padding-top: 0 !important;
@@ -859,7 +871,9 @@ main .section.three-columns-layout .section-container > div  {
   max-width: 50%;
 }
 
-main .section.three-columns-layout.with-background-image > picture, main .section.three-columns-layout.with-static-background-image > picture {
+/* stylelint-disable-next-line no-descending-specificity */
+main .section.three-columns-layout.with-background-image > picture,
+main .section.three-columns-layout.with-static-background-image > picture {
   position: absolute;
   bottom: 0;
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #302

## Changelog:
Styles for default-content-wrapper and display-block mixin

## Test URLs:
- Original: https://www.sunstar.com/about
- Before: https://main--sunstar--hlxsites.hlx.live/about
- After: https://$branch--sunstar--hlxsites.hlx.live/about

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
