### PR TITLE
Issue-469 async loading of breadcrumb content

### DIFF
--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -108,7 +108,9 @@ async function createAutoBreadcrumb(block, placeholders) {
   block.classList.add('visible');
 }
 
-export default async function decorate(block) {
-  const placeholders = await fetchPlaceholders(getLanguage());
-  createAutoBreadcrumb(block, placeholders);
+export default async function decorate(block, contentLoad = false) {
+  if (contentLoad) {
+    const placeholders = await fetchPlaceholders(getLanguage());
+    createAutoBreadcrumb(block, placeholders);
+  }
 }

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -677,6 +677,17 @@ export function loadFooter(footer) {
   return loadBlock(footerBlock);
 }
 
+export async function loadBreadcrumb() {
+  const breadcrumbBlock = document.querySelector('.breadcrumb');
+  const blockName = 'breadcrumb';
+  if (breadcrumbBlock) {
+    const breadcrumb = await import(`../blocks/${blockName}/${blockName}.js`);
+    if (breadcrumb.default) {
+      await breadcrumb.default(breadcrumbBlock, true);
+    }
+  }
+}
+
 /**
  * Setup block utils.
  */

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -15,6 +15,7 @@ import {
   isInternalPage,
   fetchPlaceholders,
   createOptimizedPicture,
+  loadBreadcrumb,
 } from './lib-franklin.js';
 
 const LCP_BLOCKS = [
@@ -554,6 +555,7 @@ async function loadLazy(doc) {
   if (!isInternalPage()) {
     loadHeader(doc.querySelector('header'));
     loadFooter(doc.querySelector('footer'));
+    await loadBreadcrumb();
     setMetaTags(main);
 
     loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #469 

## Changelog:
_Please enter each change as a new bullet point_

## Test URLs:
- Original: https://www.sunstar.com/about/business-performance
- Before: https://main--sunstar--hlxsites.hlx.live/about/business-performance
- After: https://breadcrumb-fix--sunstar--hlxsites.hlx.live/about/business-performance

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
