### PR TITLE
Restricted 0 margins to only first and last default-content-wrapper

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -637,11 +637,11 @@ main .section.auto-top-spacing .section-container {
   margin-top: 3rem !important;
 }
 
-main .section .default-content-wrapper > :first-child {
+main .section .default-content-wrapper:first-of-type > :first-child {
   margin-top: 0;
 }
 
-main .section .default-content-wrapper > :last-child {
+main .section .default-content-wrapper:last-of-type > :last-child {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #302 

## Changelog:
Restricted 0 margins to only first and last default-content-wrapper
This changes restricts the 0 top/bottom margins imposed on default-content-wrapper (introduced via https://github.com/hlxsites/sunstar/pull/486) to just the first and last occurrences of default-content-wrapper. Rhis avoids unintentional styling changes in articles pages [highlighted here.](https://cq-dev.slack.com/archives/C058KBHLBGR/p1701409541360679)

## Test URLs:
- Original: https://www.sunstar.com/about
- Before: https://main--sunstar--hlxsites.hlx.live/about
- After: https://first-last-margins--sunstar--hlxsites.hlx.live/about

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
