### PR TITLE
Omit sprite based icons

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -4,7 +4,6 @@ import {
   loadHeader,
   loadFooter,
   decorateButtons,
-  decorateIcons,
   decorateSections,
   decorateBlocks,
   decorateTemplateAndTheme,
@@ -412,7 +411,6 @@ export function decorateMain(main) {
   // hopefully forward compatible button decoration
   decorateButtons(main);
   decorateAnchors(main);
-  decorateIcons(main);
   buildAutoBlocks(main);
   decorateSections(main);
   decorateSectionsWithBackgrounds(main);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -454,7 +454,8 @@ main pre {
   margin-bottom: 0.2rem;
 }
 
-.icon.icon-angle-right-blue-bg {
+.icon.icon-angle-right-blue-bg,
+.icon.icon-angle-right-blue {
   background-image: url("/icons/angle-right-blue.svg");
   vertical-align: middle;
   width: 0.5rem;
@@ -488,11 +489,6 @@ main img {
   max-width: 100%;
   width: auto;
   height: auto;
-}
-
-/* TODO: Remove this once this icon renders correctly */
-main table a > .icon-angle-right-blue {
-  transform: rotate(180deg);
 }
 
 a:any-link {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #489 

## Changelog:
Icons are rendering twice as we have svgs specified as background images for icons and these are also rendered via svg sprite. Additionally the sprite based icons are not styled correctly. The PR poposes the omission of icon decoration via svg sprite.

## Test URLs:
- Original: https://www.sunstar.com/healthy-thinking
- Before: https://main--sunstar--hlxsites.hlx.live/healthy-thinking
- After: https://i-489--sunstar--hlxsites.hlx.live/healthy-thinking

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
