### PR TITLE
Replaced computedStyleMap with getComputedStyle for Firefox support

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -645,7 +645,7 @@ export async function waitForLCP(lcpBlocks, skipBlocks = [], maxCandidates = 1) 
 
   // load lcp candidates in default content/background images for sections
   const lcpCandidates = [...document.querySelectorAll('main img')]
-    .filter((image) => !image.computedStyleMap().get('display').value.startsWith('none'))
+    .filter((image) => getComputedStyle(image).getPropertyValue('display') !== 'none')
     .slice(0, maxCandidates);
 
   lcpCandidates.forEach(async (candidate) => {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #506 

## Changelog:
Replaced computedStyleMap with getComputedStyle for Firefox support

## Test URLs:
- Original: https://www.sunstar.com
- Before: https://main--sunstar--hlxsites.hlx.live
- After: https://i-506--sunstar--hlxsites.hlx.live

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
