### PR TITLE
Ensure that our-hr-href has correct hostname

### DIFF
--- a/blocks/network-item/network-item.js
+++ b/blocks/network-item/network-item.js
@@ -65,7 +65,15 @@ function createOurHrDiv(placeholders) {
   const ourHrDiv = document.createElement('div');
   ourHrDiv.classList.add('our-hr');
   const ourHrA = document.createElement('a');
-  ourHrA.href = placeholders['our-hr-href'];
+  if (placeholders['our-hr-href']) {
+    const url = new URL(placeholders['our-hr-href']);
+    url.hostname = window.location.hostname;
+    if (window.location.port) {
+      url.port = window.location.port;
+    }
+    ourHrA.href = url.href;
+  }
+
   ourHrA.innerText = placeholders['our-hr-text'];
   ourHrDiv.append(ourHrA);
   return ourHrDiv;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #446 

## Changelog:
Ensure that our-hr-href has correct hostname

## Test URLs:
- Original: https://www.sunstar.com/careers/career-opportunities
- Before: https://main--sunstar--hlxsites.hlx.live/careers/career-opportunities
- After: https://i-446--sunstar--hlxsites.hlx.live/careers/career-opportunities

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
