### PR TITLE
Fixing the miss due to which other class was not getting added to the very first article & that's the latest article was not listed

### DIFF
--- a/blocks/highlight/highlight.js
+++ b/blocks/highlight/highlight.js
@@ -6,7 +6,10 @@ export default async function decorate(block) {
   others.classList.add('others');
   block.querySelectorAll(':scope > div').forEach((div, index) => {
     if (index === 0) {
-      spotlight = div;
+      if (hideSpotlight) {
+        div.classList.add('other');
+        others.appendChild(div);
+      } else spotlight = div;
     } else {
       div.classList.add('other');
       others.appendChild(div);


### PR DESCRIPTION
… first index = 0 for any feed-newsroom block & that's why very first article was not listed

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue

Fixes #557 

## Changelog:
_Please enter each change as a new bullet point_

## Test URLs:
- Original: https://www.sunstar.com/newsroom
- Before: https://main--sunstar--hlxsites.hlx.page/newsroom
- After: https://issue557-newsroom-fix--sunstar--hlxsites.hlx.page/newsroom

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
